### PR TITLE
Fix canonicalize mismatch in outside-project path checks

### DIFF
--- a/dvs/src/files/add.rs
+++ b/dvs/src/files/add.rs
@@ -88,6 +88,7 @@ pub fn add_files(
     let pool = get_threadpool(matched_paths.len())?;
     let cache = try_open_cache(paths);
     let operation_id = Uuid::new_v4();
+    let canon_root = paths.repo_root().canonicalize().unwrap_or_else(|_| paths.repo_root().to_path_buf());
 
     let mut results: Vec<AddResult> = pool.install(|| {
         matched_paths
@@ -123,7 +124,7 @@ pub fn add_files(
 
                 let full_path = paths.file_path(&relative_path);
                 match full_path.canonicalize() {
-                    Ok(canonical) if !canonical.starts_with(paths.repo_root()) => {
+                    Ok(canonical) if !canonical.starts_with(&canon_root) => {
                         return AddResult {
                             path: relative_path,
                             detail: AddDetail::Error {

--- a/dvs/src/paths.rs
+++ b/dvs/src/paths.rs
@@ -131,12 +131,13 @@ impl DvsPaths {
     }
 
     pub fn validate_for_add(&self, paths: &[PathBuf]) -> Vec<(PathBuf, AddPathStatus)> {
+        let canon_root = self.repo_root.canonicalize().unwrap_or_else(|_| self.repo_root.clone());
         let mut found = Vec::new();
         for path in paths {
             let file_path = self.file_path(path);
             let status = match file_path.canonicalize() {
                 Ok(canonical) => {
-                    if !canonical.starts_with(&self.repo_root) {
+                    if !canonical.starts_with(&canon_root) {
                         AddPathStatus::OutsideProject
                     } else if canonical.is_dir() {
                         AddPathStatus::IsDirectory


### PR DESCRIPTION
## Summary
- On macOS, `tempfile::tempdir()` returns `/tmp/...` which `canonicalize()` resolves to `/private/tmp/...`, but `repo_root` stored the non-canonical path
- `starts_with` comparison between canonical file path and non-canonical repo_root incorrectly flagged valid files as "outside project"
- Fix: canonicalize `repo_root` before the comparison in both `validate_for_add` (paths.rs) and `add_files` (add.rs)

## Test plan
- [x] 3 previously failing tests now pass: `validate_for_add`, `add_files_mixed_statuses`, `add_get_roundtrip_with_explicit_paths`
- [x] Full test suite: 55/55 pass

Generated with [Claude Code](https://claude.com/claude-code)