### PR TITLE
Suppress clippy too_many_arguments on add_file

### DIFF
--- a/dvs/src/files/add.rs
+++ b/dvs/src/files/add.rs
@@ -36,6 +36,7 @@ pub enum AddDetail {
     },
 }
 
+#[allow(clippy::too_many_arguments)]
 fn add_file(
     relative_path: &Path,
     paths: &DvsPaths,


### PR DESCRIPTION
## Summary
- Adds `#[allow(clippy::too_many_arguments)]` to the internal `add_file` function which takes 8 parameters
- This is a private function; the proper fix (grouping into an `AddOptions` struct) is done in the `vvv` feature branch

## Test plan
- [x] `cargo clippy -p dvs -p dvs-cli` passes with zero warnings

Generated with [Claude Code](https://claude.com/claude-code)