### PR TITLE
warn: storage within root

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use anyhow::bail;
 use anyhow::{Result, anyhow};
 use clap::{Parser, Subcommand};
 use serde_json::json;
@@ -119,7 +120,7 @@ fn try_main() -> Result<()> {
                 .canonicalize()?
                 .starts_with(root.canonicalize()?)
             {
-                println!("Warning: The given storage path is within the repository.")
+                bail!("The given storage path is within the repository.")
             }
 
             let repo_root = init(&root, config)?;


### PR DESCRIPTION
Fixes #48

Current behavior:

```shell
❯ mkdir tmp
❯ cd tmp
❯ mkdir storage_in_path
❯ dvs init storage_in_path
DVS Initialized at "/Users/elea/Documents/a2ai_github/dvs2/tmp"
```
i.e. something like

```shell
├── dvs.toml
├── f1.bin
└── storage_in_path
    ├── audit.log.jsonl
    └── dc
        └── 4c774b7a2c5d483ef32c80ddd82572535ca23fe1f3157bad8accc64fc76c0f
```
this is not recommended; thus this PR produces a warning:

```shell
❯ dvs init .storage
Warning: The given storage path is within the repository.
DVS Initialized at "/Users/elea/Documents/a2ai_github/dvs2/tmp2"

❯ tree -a .  
.
├── .dvs
│   ├── .cache
│   │   └── dvs.db
│   └── f1.bin.dvs
├── .storage
│   ├── 6d
│   │   └── 95ba5e9961c861af368e5a7137713c585aaac450409c688739bc40a64d1992
│   └── audit.log.jsonl
├── dvs.toml
└── f1.bin

5 directories, 6 files
```