### PR TITLE
dvs: gate anyhow! import behind cfg(unix)

### DIFF
--- a/dvs/src/backends/local.rs
+++ b/dvs/src/backends/local.rs
@@ -4,7 +4,9 @@ use std::io::{BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
+#[cfg(unix)]
+use anyhow::anyhow;
 use fs_err as fs;
 use serde::{Deserialize, Serialize};
 

--- a/dvs/src/backends/local.rs
+++ b/dvs/src/backends/local.rs
@@ -4,9 +4,9 @@ use std::io::{BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use anyhow::{Result, bail};
 #[cfg(unix)]
 use anyhow::anyhow;
+use anyhow::{Result, bail};
 use fs_err as fs;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## Summary

- Windows CI emits `warning: unused import: `anyhow`` for `dvs/src/backends/local.rs:7`.
- The `anyhow!` macro is only referenced inside `#[cfg(unix)]` helpers (`resolve_group`, `detect_primary_group`); `Result` and `bail!` are used unconditionally.
- Split the import so `anyhow` is only pulled in when `cfg(unix)`.

## Test plan

- [ ] `cargo check -p dvs` on Linux/macOS: clean
- [ ] Windows CI: unused_imports warning gone

Generated with [Claude Code](https://claude.com/claude-code)