### PR TITLE
dvs-rpkg / dvs-cli parity fixes

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -14,7 +14,7 @@ use dvs::init::init;
 use dvs::paths::DvsPaths;
 use dvs::{
     AddDetail, Compression, FileMetadata, FileProgress, GetDetail, Outcome, Status, StatusDetail,
-    StatusFilter, add_files, format_size, get_files, get_status,
+    StatusFilter, add_files, format_size, get_files, get_status, set_num_threads,
 };
 
 #[derive(Debug, Subcommand)]
@@ -93,6 +93,10 @@ pub struct Cli {
     /// Output results as JSON
     #[clap(long, global = true)]
     pub json: bool,
+
+    /// Number of threads for parallel operations (0 = auto-detect)
+    #[clap(long, global = true)]
+    pub threads: Option<usize>,
 
     #[clap(subcommand)]
     pub command: Command,
@@ -179,6 +183,9 @@ fn try_main() -> Result<()> {
     env_logger::init();
 
     let cli = Cli::parse();
+    if let Some(n) = cli.threads {
+        set_num_threads(n);
+    }
     let current_dir = std::env::current_dir()?;
 
     match cli.command {

--- a/dvs-rpkg/src/rust/lib.rs
+++ b/dvs-rpkg/src/rust/lib.rs
@@ -1,7 +1,8 @@
 //! dvs-rpkg: Data Version Control System R Bindings
 //!
 //! This crate provides R bindings for the DVS (Data Version Control System).
-//! Results are returned as JSON strings for efficient parsing in R.
+//! Results are returned as R DataFrames (and Lists) via miniextendr's
+//! `AsSerializeRow` / `ColumnarDataFrame` converters.
 
 mod cli_progress;
 
@@ -172,6 +173,20 @@ pub(crate) fn dvs_init(
     if let Some(m) = metadata_folder_name {
         config.set_metadata_folder_name(m);
     }
+
+    // Mirrors the CLI guard: refuse to store data inside the repo it's versioning.
+    let abs_storage = if storage_path.exists() {
+        std::fs::canonicalize(&storage_path)?
+    } else if let Some(parent) = storage_path.parent().filter(|p| p.exists()) {
+        std::fs::canonicalize(parent)?.join(storage_path.file_name().unwrap())
+    } else {
+        std::path::absolute(&storage_path)?
+    };
+    let abs_root = std::fs::canonicalize(&root_dir)?;
+    if abs_storage.starts_with(&abs_root) {
+        return Err(anyhow!("The given storage path is within the repository."));
+    }
+
     init(&root_dir, config)?;
 
     r_println!("DVS Initialized");


### PR DESCRIPTION
## Summary

Three small parity/consistency fixes surfaced by a review of dvs-rpkg against dvs-cli:

1. **dvs_init guard** — dvs-cli bails when the storage path is inside the repo being versioned. dvs-rpkg did not. Ported the same check (canonicalize storage + root, reject if `starts_with`) into the R binding.
2. **CLI `--threads`** — the R package has `dvs_set_threads`; dvs-cli had no counterpart. Added a global `--threads` clap option that calls `dvs::set_num_threads` before dispatch.
3. **Stale crate doc** — `dvs-rpkg/src/rust/lib.rs` claimed results were JSON strings. They have been DataFrames / Lists via miniextendr for a while; updated the doc to match.

A fourth review item (no `with_metadata` toggle on R's `dvs_status`) is tracked in #127 rather than fixed here — it's an API-surface addition, not a bug.

## Test plan

- [ ] `cargo check` root workspace
- [ ] `cargo check --manifest-path dvs-rpkg/src/rust/Cargo.toml`
- [ ] `cargo fmt --all --check`
- [ ] CI matrix (linux/macos/windows)
- [ ] Manual: `dvs init <path-inside-repo>` from R now errors
- [ ] Manual: `dvs --threads 4 status` respects thread override

Generated with [Claude Code](https://claude.com/claude-code)