### PR TITLE
ci: restrict test matrix to linux only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,24 @@ jobs:
     name: test
     runs-on: ${{ matrix.os }}
     strategy:
+      # macOS and Windows are temporarily disabled; see #129 for re-enable
+      # before the next release. To restore the full matrix, add `macos` and
+      # `windows` back to `build:` and uncomment the two include blocks
+      # below. The Windows --xz skip in the "Vendor rpkg deps" step is
+      # retained so the matrix can be restored without extra surgery.
       matrix:
-        build: [linux, macos, windows]
+        build: [linux]
+        # build: [linux, macos, windows]
         include:
           - build: linux
             os: ubuntu-22.04
             rust: stable
-          - build: macos
-            os: macOS-latest
-            rust: stable
-          - build: windows
-            os: windows-2022
-            rust: stable
+          # - build: macos
+          #   os: macOS-latest
+          #   rust: stable
+          # - build: windows
+          #   os: windows-2022
+          #   rust: stable
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust


### PR DESCRIPTION
## Summary

- Drop macOS and Windows jobs from the CI matrix for now so we stop blocking on platform-specific CI churn.
- Keep the Windows-aware `COMPRESS_FLAG` logic in the vendor step intact so flipping the matrix back later is a single-line change.

Tracker: #129 — re-enable the full matrix before the next release and re-verify macOS + Windows.

## Test plan

- [x] CI passes on this PR (linux only)
- [ ] Matrix restoration in #129 brings macOS and Windows green

Generated with [Claude Code](https://claude.com/claude-code)