### PR TITLE
dvs-rpkg: use git dep for dvs so isolated installs work

### DIFF
--- a/dvs-rpkg/src/rust/Cargo.lock
+++ b/dvs-rpkg/src/rust/Cargo.lock
@@ -151,6 +151,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "dvs"
 version = "0.3.0"
+source = "git+https://github.com/A2-ai/dvs2#6a09707b6b0fc79bbe2245875c142d09e6926f25"
 dependencies = [
  "anyhow",
  "blake3",

--- a/dvs-rpkg/src/rust/Cargo.toml
+++ b/dvs-rpkg/src/rust/Cargo.toml
@@ -18,13 +18,23 @@ default = []
 nonapi = ["miniextendr-api/nonapi"]
 connections = ["miniextendr-api/connections"]
 
-# Source-of-truth deps: git for miniextendr, monorepo path for dvs.
+# Source-of-truth deps: git for both miniextendr and dvs.
+#
+# Both use git so the crate is resolvable when R extracts `dvs-rpkg/`
+# alone into a tempdir (rv sync / install.packages() / remotes::install_github()),
+# which does NOT bring sibling monorepo crates along. A path dep to
+# `../../../dvs` fails `cargo metadata` in that context.
+#
 # `cargo revendor --freeze` rewrites these to vendor/ paths when packaging
 # for CRAN. The frozen form is produced by `just vendor` and shipped in
 # inst/vendor.tar.xz; never commit the frozen Cargo.toml itself.
+#
+# Monorepo dev iterating on local `dvs`: add an uncommitted
+# `[patch."https://github.com/A2-ai/dvs2"] dvs = { path = "../../../dvs" }`
+# block, or rely on `just` recipes that vendor from the local checkout.
 [dependencies]
 miniextendr-api = { git = "https://github.com/A2-ai/miniextendr", features = ["serde"] }
-dvs = { path = "../../../dvs" }
+dvs = { git = "https://github.com/A2-ai/dvs2", package = "dvs" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"


### PR DESCRIPTION
## What

Change `dvs-rpkg/src/rust/Cargo.toml`:

```diff
-dvs = { path = "../../../dvs" }
+dvs = { git = "https://github.com/A2-ai/dvs2", package = "dvs" }
```

## Why

When R installs `dvs-rpkg` via `install.packages()`, `remotes::install_github(subdir = "dvs-rpkg")`, or `rv sync`, only the `dvs-rpkg/` subdirectory is extracted into the temp build directory. Sibling monorepo crates (`dvs/`) are left behind.

The path dep `../../../dvs` then resolves to `/tmp/.../dvs`, which does not exist. `cargo metadata` fails immediately, so the auto-vendor fallback added in #132 can't run — cargo-revendor needs `cargo metadata` to succeed before it can collect dependencies.

Reported failure (after #132 merged):

```
configure: vendor/ not found and inst/vendor.tar.xz not present — auto-vendoring (needs network)
cargo-revendor: vendoring deps from /tmp/.tmp1uLPu9/src/rust/Cargo.toml
Error: failed to load metadata from /tmp/.tmp1uLPu9/src/rust/Cargo.toml

Caused by:
    `cargo metadata` exited with an error: error: failed to load manifest for dependency `dvs`
    Caused by:
      failed to read `/tmp/dvs/Cargo.toml`
    Caused by:
      No such file or directory (os error 2)
```

`miniextendr-api` already uses a git dep for this exact reason. `dvs` needs the same treatment.

## Verification

Simulated isolated-install context locally:

```
cp -r dvs-rpkg /tmp/revendor-test/
cd /tmp/revendor-test/dvs-rpkg
cargo revendor --manifest-path src/rust/Cargo.toml --output /tmp/revendor-test/vendor --strip-all
# → vendored 130 crates including dvs-0.3.0/
```

## Monorepo dev

For contributors iterating on the local `dvs` crate, add an uncommitted override to `dvs-rpkg/src/rust/Cargo.toml`:

```toml
[patch."https://github.com/A2-ai/dvs2"]
dvs = { path = "../../../dvs" }
```

Or rely on `just` vendor recipes that source from the local checkout.

## Test plan

- [ ] `rv sync` from a demo project installs `dvs-rpkg` from github successfully
- [ ] `just rcmdinstall` still works in the monorepo (cargo will fetch dvs from git HEAD on first build)
- [ ] CI green