### PR TITLE
fix: accept absolute paths in resolve_paths_for_get (closes #136)

### DIFF
--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -112,7 +112,12 @@ pub fn resolve_paths_for_get(
         paths
             .into_iter()
             .map(|p| {
-                if let Some(prefix) = cwd_prefix {
+                if p.is_absolute() {
+                    match p.strip_prefix(dvs_paths.repo_root()) {
+                        Ok(r) => r.to_path_buf(),
+                        Err(_) => p,
+                    }
+                } else if let Some(prefix) = cwd_prefix {
                     prefix.join(&p)
                 } else {
                     p
@@ -286,5 +291,36 @@ mod tests {
         assert!(result.contains(&PathBuf::from("foo.txt")));
         assert!(result.contains(&PathBuf::from("data/a.csv")));
         assert!(result.contains(&PathBuf::from("data/subdir/c.csv")));
+    }
+
+    #[test]
+    fn get_absolute_file_path() {
+        let (temp, dvs_paths) = setup_test_repo();
+        let abs_path = temp.path().canonicalize().unwrap().join("foo.txt");
+        let result = resolve_paths_for_get(vec![abs_path], None, &dvs_paths).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&PathBuf::from("foo.txt")));
+    }
+
+    #[test]
+    fn get_absolute_directory_path() {
+        let (temp, dvs_paths) = setup_test_repo();
+        let abs_path = temp.path().canonicalize().unwrap().join("data");
+        let result = resolve_paths_for_get(vec![abs_path], None, &dvs_paths).unwrap();
+
+        assert!(result.contains(&PathBuf::from("data/a.csv")));
+        assert!(result.contains(&PathBuf::from("data/subdir/c.csv")));
+        assert!(!result.contains(&PathBuf::from("foo.txt")));
+    }
+
+    #[test]
+    fn add_absolute_file_path() {
+        let (temp, dvs_paths) = setup_test_repo();
+        let abs_path = temp.path().canonicalize().unwrap().join("foo.txt");
+        let result = resolve_paths_for_add(vec![abs_path], None, &dvs_paths).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&PathBuf::from("foo.txt")));
     }
 }


### PR DESCRIPTION
## Summary

- `resolve_paths_for_get` built `dir_filters` via `cwd_prefix.join(p)`, which silently discards the prefix when `p` is absolute — leaving an absolute path that can never `starts_with` a repo-relative `tracked_path`, so every tracked file was filtered out and the call errored with "No files to get"
- Added an `is_absolute()` guard that strips `repo_root` from the path first, mirroring the pattern already in `StatusFilter::from_user_paths` in `status.rs`
- `resolve_paths_for_add` was already correct (it calls `canonicalize()` which handles symlinks, then `strip_prefix`); this PR brings `get` to parity

## Test plan

- [ ] `get_absolute_file_path`: pass absolute path to a tracked file → returns the correct repo-relative path
- [ ] `get_absolute_directory_path`: pass absolute path to a directory → returns all tracked files under it
- [ ] `add_absolute_file_path`: confirms existing `add` behaviour is preserved
- [ ] All existing globbing tests still pass (`cargo test -p dvs --lib globbing`)

Generated with [Claude Code](https://claude.com/claude-code)