### PR TITLE
fix(get): canonicalize absolute paths and reject outside-project paths

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -318,7 +318,7 @@ fn try_main() -> Result<()> {
             } else {
                 Some(StatusFilter::from_user_paths(
                     user_paths, recursive, &dvs_paths,
-                ))
+                )?)
             };
             let mut statuses = get_status(&dvs_paths, filter.as_ref())?;
             if !show_all {

--- a/dvs-rpkg/src/rust/lib.rs
+++ b/dvs-rpkg/src/rust/lib.rs
@@ -308,7 +308,7 @@ pub(crate) fn dvs_status(
             paths,
             recursive.unwrap_or(false),
             &dvs_paths,
-        ))
+        )?)
     };
     let mut statuses = get_status(&dvs_paths, filter.as_ref())?;
     if !show_all {

--- a/dvs/src/files/status.rs
+++ b/dvs/src/files/status.rs
@@ -1,7 +1,7 @@
 use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use fs_err as fs;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -9,6 +9,7 @@ use walkdir::WalkDir;
 
 use crate::cache::{HashCache, try_open_cache};
 use crate::files::metadata::FileMetadata;
+use crate::globbing::canonicalize_existing_prefix;
 use crate::paths::DvsPaths;
 use crate::utils::get_threadpool;
 use crate::{Status, cache};
@@ -63,32 +64,50 @@ fn normalize_path(p: PathBuf) -> Option<PathBuf> {
 impl StatusFilter {
     /// Create a filter from user-provided paths (relative to cwd) and a recursive flag.
     /// Translates cwd-relative paths to repo-root-relative using `dvs_paths.cwd_relative_to_root()`.
+    /// Returns an error listing every input that does not resolve inside the repo (absolute
+    /// paths outside `repo_root`, or relative paths that `../..` past it).
     pub fn from_user_paths(
         user_paths: Vec<PathBuf>,
         recursive: bool,
         dvs_paths: &DvsPaths,
-    ) -> Self {
+    ) -> Result<Self> {
         let cwd_prefix = dvs_paths.cwd_relative_to_root();
         let repo_root = dvs_paths.repo_root();
-        let paths = user_paths
-            .into_iter()
-            .filter_map(|p| {
-                if p.is_absolute() {
-                    p.strip_prefix(repo_root)
-                        .ok()
-                        .map(|r| r.to_path_buf())
-                        .and_then(normalize_path)
+        let mut paths = Vec::with_capacity(user_paths.len());
+        let mut outside = Vec::new();
+        for p in user_paths {
+            let resolved = if p.is_absolute() {
+                // Canonicalize so symlinked prefixes (e.g. macOS `/tmp` -> `/private/tmp`)
+                // compare equal to the canonical `repo_root`. Fall back to the deepest
+                // existing ancestor when the file itself does not exist.
+                let canonical = canonicalize_existing_prefix(&p).unwrap_or_else(|| p.clone());
+                canonical
+                    .strip_prefix(repo_root)
+                    .ok()
+                    .map(|r| r.to_path_buf())
+                    .and_then(normalize_path)
+            } else {
+                let joined = if let Some(prefix) = cwd_prefix {
+                    prefix.join(&p)
                 } else {
-                    let joined = if let Some(prefix) = cwd_prefix {
-                        prefix.join(&p)
-                    } else {
-                        p
-                    };
-                    normalize_path(joined)
-                }
-            })
-            .collect();
-        StatusFilter { paths, recursive }
+                    p.clone()
+                };
+                normalize_path(joined)
+            };
+            match resolved {
+                Some(r) => paths.push(r),
+                None => outside.push(p),
+            }
+        }
+        if !outside.is_empty() {
+            let listed = outside
+                .iter()
+                .map(|p| format!("  - {}", p.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            bail!("The following paths are outside the project:\n{listed}");
+        }
+        Ok(StatusFilter { paths, recursive })
     }
 
     fn matches(&self, tracked_path: &Path) -> bool {
@@ -495,7 +514,7 @@ mod tests {
 
         // Absolute path filter via from_user_paths
         let abs_path = paths.repo_root().join("dir1/b.txt");
-        let filter = StatusFilter::from_user_paths(vec![abs_path], false, &paths);
+        let filter = StatusFilter::from_user_paths(vec![abs_path], false, &paths).unwrap();
         let statuses = get_status(&paths, Some(&filter)).unwrap();
         assert_eq!(statuses.len(), 1);
         assert_eq!(statuses[0].path, PathBuf::from("dir1/b.txt"));
@@ -517,15 +536,16 @@ mod tests {
             ".dvs",
         )
         .unwrap();
-        let filter = StatusFilter::from_user_paths(vec![PathBuf::from("../foo")], false, &paths);
+        let filter = StatusFilter::from_user_paths(vec![PathBuf::from("../foo")], false, &paths)
+            .unwrap();
         assert_eq!(filter.paths, vec![PathBuf::from("foo")]);
 
-        // From subdir/: ../../foo → escapes root → dropped (empty)
-        let filter = StatusFilter::from_user_paths(vec![PathBuf::from("../../foo")], false, &paths);
-        assert!(
-            filter.paths.is_empty(),
-            "../../foo should escape root and be dropped"
-        );
+        // From subdir/: ../../foo → escapes root → reported as outside (not silent)
+        let result =
+            StatusFilter::from_user_paths(vec![PathBuf::from("../../foo")], false, &paths);
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("outside the project"), "unexpected error: {err}");
+        assert!(err.contains("../../foo"), "missing offending path in: {err}");
 
         // From subdir/deep/: ../../foo → resolves to "foo" (valid, 2 levels up = root)
         let paths_deep = DvsPaths::new(
@@ -535,17 +555,60 @@ mod tests {
         )
         .unwrap();
         let filter =
-            StatusFilter::from_user_paths(vec![PathBuf::from("../../foo")], false, &paths_deep);
+            StatusFilter::from_user_paths(vec![PathBuf::from("../../foo")], false, &paths_deep)
+                .unwrap();
         assert_eq!(filter.paths, vec![PathBuf::from("foo")]);
 
         // From subdir/: ../dir2/file.txt → resolves to "dir2/file.txt"
         let filter =
-            StatusFilter::from_user_paths(vec![PathBuf::from("../dir2/file.txt")], false, &paths);
+            StatusFilter::from_user_paths(vec![PathBuf::from("../dir2/file.txt")], false, &paths)
+                .unwrap();
         assert_eq!(filter.paths, vec![PathBuf::from("dir2/file.txt")]);
 
         // From subdir/: absolute path with .. like <root>/subdir/../a.txt → normalizes to "a.txt"
         let abs_with_dotdot = root.join("subdir/../a.txt");
-        let filter = StatusFilter::from_user_paths(vec![abs_with_dotdot], false, &paths);
+        let filter =
+            StatusFilter::from_user_paths(vec![abs_with_dotdot], false, &paths).unwrap();
         assert_eq!(filter.paths, vec![PathBuf::from("a.txt")]);
+    }
+
+    #[test]
+    fn from_user_paths_absolute_outside_repo_errors() {
+        let (_tmp, root) = create_temp_git_repo();
+        let (_config, _dvs_dir) = init_dvs_repo(&root);
+        let paths = DvsPaths::new(root.clone(), root.clone(), ".dvs").unwrap();
+
+        let outside = tempfile::TempDir::new().unwrap();
+        let abs_a = outside.path().canonicalize().unwrap().join("a.txt");
+        let abs_b = outside.path().canonicalize().unwrap().join("b.txt");
+        let disp_a = abs_a.display().to_string();
+        let disp_b = abs_b.display().to_string();
+
+        let err = StatusFilter::from_user_paths(vec![abs_a, abs_b], false, &paths)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("outside the project"), "unexpected error: {err}");
+        assert!(err.contains(&disp_a), "missing first outside path in: {err}");
+        assert!(err.contains(&disp_b), "missing second outside path in: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn from_user_paths_absolute_via_symlink() {
+        use std::os::unix::fs::symlink;
+        let (_tmp, root) = create_temp_git_repo();
+        let (_config, _dvs_dir) = init_dvs_repo(&root);
+        fs::create_dir_all(root.join("dir1")).unwrap();
+        fs::write(root.join("dir1/b.txt"), b"").unwrap();
+        let paths = DvsPaths::new(root.clone(), root.clone(), ".dvs").unwrap();
+
+        let link_holder = tempfile::TempDir::new().unwrap();
+        let link_path = link_holder.path().join("repo-link");
+        symlink(&root, &link_path).unwrap();
+
+        let abs_via_link = link_path.join("dir1/b.txt");
+        let filter =
+            StatusFilter::from_user_paths(vec![abs_via_link], false, &paths).unwrap();
+        assert_eq!(filter.paths, vec![PathBuf::from("dir1/b.txt")]);
     }
 }

--- a/dvs/src/files/status.rs
+++ b/dvs/src/files/status.rs
@@ -536,16 +536,21 @@ mod tests {
             ".dvs",
         )
         .unwrap();
-        let filter = StatusFilter::from_user_paths(vec![PathBuf::from("../foo")], false, &paths)
-            .unwrap();
+        let filter =
+            StatusFilter::from_user_paths(vec![PathBuf::from("../foo")], false, &paths).unwrap();
         assert_eq!(filter.paths, vec![PathBuf::from("foo")]);
 
         // From subdir/: ../../foo → escapes root → reported as outside (not silent)
-        let result =
-            StatusFilter::from_user_paths(vec![PathBuf::from("../../foo")], false, &paths);
+        let result = StatusFilter::from_user_paths(vec![PathBuf::from("../../foo")], false, &paths);
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("outside the project"), "unexpected error: {err}");
-        assert!(err.contains("../../foo"), "missing offending path in: {err}");
+        assert!(
+            err.contains("outside the project"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("../../foo"),
+            "missing offending path in: {err}"
+        );
 
         // From subdir/deep/: ../../foo → resolves to "foo" (valid, 2 levels up = root)
         let paths_deep = DvsPaths::new(
@@ -567,8 +572,7 @@ mod tests {
 
         // From subdir/: absolute path with .. like <root>/subdir/../a.txt → normalizes to "a.txt"
         let abs_with_dotdot = root.join("subdir/../a.txt");
-        let filter =
-            StatusFilter::from_user_paths(vec![abs_with_dotdot], false, &paths).unwrap();
+        let filter = StatusFilter::from_user_paths(vec![abs_with_dotdot], false, &paths).unwrap();
         assert_eq!(filter.paths, vec![PathBuf::from("a.txt")]);
     }
 
@@ -587,9 +591,18 @@ mod tests {
         let err = StatusFilter::from_user_paths(vec![abs_a, abs_b], false, &paths)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("outside the project"), "unexpected error: {err}");
-        assert!(err.contains(&disp_a), "missing first outside path in: {err}");
-        assert!(err.contains(&disp_b), "missing second outside path in: {err}");
+        assert!(
+            err.contains("outside the project"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains(&disp_a),
+            "missing first outside path in: {err}"
+        );
+        assert!(
+            err.contains(&disp_b),
+            "missing second outside path in: {err}"
+        );
     }
 
     #[cfg(unix)]
@@ -607,8 +620,7 @@ mod tests {
         symlink(&root, &link_path).unwrap();
 
         let abs_via_link = link_path.join("dir1/b.txt");
-        let filter =
-            StatusFilter::from_user_paths(vec![abs_via_link], false, &paths).unwrap();
+        let filter = StatusFilter::from_user_paths(vec![abs_via_link], false, &paths).unwrap();
         assert_eq!(filter.paths, vec![PathBuf::from("dir1/b.txt")]);
     }
 }

--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -130,25 +130,33 @@ pub fn resolve_paths_for_get(
     let dir_filters: Vec<PathBuf> = if paths.is_empty() {
         vec![cwd_prefix.map(|p| p.to_path_buf()).unwrap_or_default()]
     } else {
-        paths
-            .into_iter()
-            .map(|p| -> Result<PathBuf> {
-                if p.is_absolute() {
-                    // Canonicalize so that symlinked prefixes (e.g. `/tmp` ->
-                    // `/private/tmp` on macOS) compare equal to the already-canonical
-                    // `repo_root`. The file may not exist yet — that's fine.
-                    let canonical = canonicalize_existing_prefix(&p).unwrap_or_else(|| p.clone());
-                    match canonical.strip_prefix(dvs_paths.repo_root()) {
-                        Ok(r) => Ok(r.to_path_buf()),
-                        Err(_) => bail!("Path is outside project: {}", p.display()),
-                    }
-                } else if let Some(prefix) = cwd_prefix {
-                    Ok(prefix.join(&p))
-                } else {
-                    Ok(p)
+        let mut filters = Vec::with_capacity(paths.len());
+        let mut outside = Vec::new();
+        for p in paths {
+            if p.is_absolute() {
+                // Canonicalize so that symlinked prefixes (e.g. `/tmp` ->
+                // `/private/tmp` on macOS) compare equal to the already-canonical
+                // `repo_root`. The file may not exist yet — that's fine.
+                let canonical = canonicalize_existing_prefix(&p).unwrap_or_else(|| p.clone());
+                match canonical.strip_prefix(dvs_paths.repo_root()) {
+                    Ok(r) => filters.push(r.to_path_buf()),
+                    Err(_) => outside.push(p),
                 }
-            })
-            .collect::<Result<Vec<_>>>()?
+            } else if let Some(prefix) = cwd_prefix {
+                filters.push(prefix.join(&p));
+            } else {
+                filters.push(p);
+            }
+        }
+        if !outside.is_empty() {
+            let listed = outside
+                .iter()
+                .map(|p| format!("  - {}", p.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            bail!("The following paths are outside the project:\n{listed}");
+        }
+        filters
     };
 
     // Walk all metadata files
@@ -369,10 +377,29 @@ mod tests {
         let (_temp, dvs_paths) = setup_test_repo();
         let outside = TempDir::new().unwrap();
         let abs_path = outside.path().canonicalize().unwrap().join("bogus.txt");
+        let expected_display = abs_path.display().to_string();
         let result = resolve_paths_for_get(vec![abs_path], None, &dvs_paths);
 
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("outside project"), "unexpected error: {err}");
+        assert!(err.contains("outside the project"), "unexpected error: {err}");
+        assert!(err.contains(&expected_display), "missing path in: {err}");
+    }
+
+    #[test]
+    fn get_reports_all_outside_paths_not_just_first() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        let outside_a = TempDir::new().unwrap();
+        let outside_b = TempDir::new().unwrap();
+        let p_a = outside_a.path().canonicalize().unwrap().join("a.txt");
+        let p_b = outside_b.path().canonicalize().unwrap().join("b.txt");
+        let disp_a = p_a.display().to_string();
+        let disp_b = p_b.display().to_string();
+
+        let result = resolve_paths_for_get(vec![p_a, p_b], None, &dvs_paths);
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains(&disp_a), "missing first outside path in: {err}");
+        assert!(err.contains(&disp_b), "missing second outside path in: {err}");
     }
 
     // Covers macOS `/tmp` -> `/private/tmp` class of issues: an absolute

--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -12,7 +12,7 @@ use walkdir::WalkDir;
 /// to canonicalizing the deepest existing ancestor and appending the remainder.
 /// This is how absolute user-paths get compared consistently against the
 /// canonicalized `repo_root`.
-fn canonicalize_existing_prefix(p: &Path) -> Option<PathBuf> {
+pub(crate) fn canonicalize_existing_prefix(p: &Path) -> Option<PathBuf> {
     if let Ok(canonical) = p.canonicalize() {
         return Some(canonical);
     }

--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -1,11 +1,32 @@
 use std::collections::HashSet;
 use std::ffi::OsStr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::paths::DvsPaths;
 use anyhow::{Result, anyhow, bail};
 use globset::{GlobBuilder, GlobMatcher};
 use walkdir::WalkDir;
+
+/// Canonicalize an absolute path, resolving symlinks. If the path itself does
+/// not exist (the `get` case: user wants to restore a deleted file), fall back
+/// to canonicalizing the deepest existing ancestor and appending the remainder.
+/// This is how absolute user-paths get compared consistently against the
+/// canonicalized `repo_root`.
+fn canonicalize_existing_prefix(p: &Path) -> Option<PathBuf> {
+    if let Ok(canonical) = p.canonicalize() {
+        return Some(canonical);
+    }
+    let mut ancestor = p.parent();
+    while let Some(dir) = ancestor {
+        if let Ok(canonical_dir) = dir.canonicalize() {
+            if let Ok(rest) = p.strip_prefix(dir) {
+                return Some(canonical_dir.join(rest));
+            }
+        }
+        ancestor = dir.parent();
+    }
+    None
+}
 
 /// Builds the glob matching the rg behaviour
 /// eg "*.csv" will not match `some/dir/test.csv`
@@ -104,26 +125,30 @@ pub fn resolve_paths_for_get(
     // Get cwd-relative prefix for converting user paths to repo-root-relative
     let cwd_prefix = dvs_paths.cwd_relative_to_root();
 
-    // Convert user paths to repo-relative directory filters
-    // If no paths given, default to cwd (or repo root if at root)
+    // Convert user paths to repo-relative directory filters.
+    // If no paths given, default to cwd (or repo root if at root).
     let dir_filters: Vec<PathBuf> = if paths.is_empty() {
         vec![cwd_prefix.map(|p| p.to_path_buf()).unwrap_or_default()]
     } else {
         paths
             .into_iter()
-            .map(|p| {
+            .map(|p| -> Result<PathBuf> {
                 if p.is_absolute() {
-                    match p.strip_prefix(dvs_paths.repo_root()) {
-                        Ok(r) => r.to_path_buf(),
-                        Err(_) => p,
+                    // Canonicalize so that symlinked prefixes (e.g. `/tmp` ->
+                    // `/private/tmp` on macOS) compare equal to the already-canonical
+                    // `repo_root`. The file may not exist yet — that's fine.
+                    let canonical = canonicalize_existing_prefix(&p).unwrap_or_else(|| p.clone());
+                    match canonical.strip_prefix(dvs_paths.repo_root()) {
+                        Ok(r) => Ok(r.to_path_buf()),
+                        Err(_) => bail!("Path is outside project: {}", p.display()),
                     }
                 } else if let Some(prefix) = cwd_prefix {
-                    prefix.join(&p)
+                    Ok(prefix.join(&p))
                 } else {
-                    p
+                    Ok(p)
                 }
             })
-            .collect()
+            .collect::<Result<Vec<_>>>()?
     };
 
     // Walk all metadata files
@@ -319,6 +344,51 @@ mod tests {
         let (temp, dvs_paths) = setup_test_repo();
         let abs_path = temp.path().canonicalize().unwrap().join("foo.txt");
         let result = resolve_paths_for_add(vec![abs_path], None, &dvs_paths).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&PathBuf::from("foo.txt")));
+    }
+
+    // Issue #136 repro: file was added, then deleted, then `get` with the
+    // same absolute path should restore it. `canonicalize()` on the missing
+    // file fails, so we must fall back to canonicalizing the parent.
+    #[test]
+    fn get_absolute_path_missing_file_parent_exists() {
+        let (temp, dvs_paths) = setup_test_repo();
+        fs::remove_file(temp.path().join("foo.txt")).unwrap();
+
+        let abs_path = temp.path().canonicalize().unwrap().join("foo.txt");
+        let result = resolve_paths_for_get(vec![abs_path], None, &dvs_paths).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&PathBuf::from("foo.txt")));
+    }
+
+    #[test]
+    fn get_absolute_path_outside_repo_errors() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        let outside = TempDir::new().unwrap();
+        let abs_path = outside.path().canonicalize().unwrap().join("bogus.txt");
+        let result = resolve_paths_for_get(vec![abs_path], None, &dvs_paths);
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("outside project"), "unexpected error: {err}");
+    }
+
+    // Covers macOS `/tmp` -> `/private/tmp` class of issues: an absolute
+    // path that traverses a symlink must still resolve to the canonical
+    // repo_root.
+    #[cfg(unix)]
+    #[test]
+    fn get_absolute_path_via_symlink() {
+        use std::os::unix::fs::symlink;
+        let (temp, dvs_paths) = setup_test_repo();
+        let link_holder = TempDir::new().unwrap();
+        let link_path = link_holder.path().join("repo-link");
+        symlink(temp.path(), &link_path).unwrap();
+
+        let abs_path = link_path.join("foo.txt");
+        let result = resolve_paths_for_get(vec![abs_path], None, &dvs_paths).unwrap();
 
         assert_eq!(result.len(), 1);
         assert!(result.contains(&PathBuf::from("foo.txt")));

--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -381,7 +381,10 @@ mod tests {
         let result = resolve_paths_for_get(vec![abs_path], None, &dvs_paths);
 
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("outside the project"), "unexpected error: {err}");
+        assert!(
+            err.contains("outside the project"),
+            "unexpected error: {err}"
+        );
         assert!(err.contains(&expected_display), "missing path in: {err}");
     }
 
@@ -398,8 +401,14 @@ mod tests {
         let result = resolve_paths_for_get(vec![p_a, p_b], None, &dvs_paths);
 
         let err = result.unwrap_err().to_string();
-        assert!(err.contains(&disp_a), "missing first outside path in: {err}");
-        assert!(err.contains(&disp_b), "missing second outside path in: {err}");
+        assert!(
+            err.contains(&disp_a),
+            "missing first outside path in: {err}"
+        );
+        assert!(
+            err.contains(&disp_b),
+            "missing second outside path in: {err}"
+        );
     }
 
     // Covers macOS `/tmp` -> `/private/tmp` class of issues: an absolute


### PR DESCRIPTION
## Summary

Stacked on #138. Fixes two follow-up items flagged in #138's review:

1. **Canonicalize absolute user paths before `strip_prefix(repo_root)`.** `repo_root` is canonical; the user path was not. Paths through symlinks (e.g. `/tmp/repo/foo.txt` on macOS where `/tmp -> /private/tmp`) silently fell through to "No files to get" — the same symptom as the original #136 bug.
2. **Bail explicitly when the absolute path is outside the project.** Previously the absolute path fell through unchanged and would fail to match any `tracked_path`, producing a confusing "No files to get" error. Now it returns `Path is outside project: ...`.

The new `canonicalize_existing_prefix` helper canonicalizes the path directly, or falls back to canonicalizing the deepest existing ancestor when the file itself does not exist — which is the common `get`-to-restore case (cf. the #136 repro, where the file was deleted before `get`).

## Test plan

- [ ] `get_absolute_path_missing_file_parent_exists` — reproduces the exact #136 scenario (add → delete → get with absolute path)
- [ ] `get_absolute_path_outside_repo_errors` — absolute path to a different temp dir returns an explicit "outside project" error
- [ ] `get_absolute_path_via_symlink` (Unix) — absolute path through a symlink resolves correctly; covers the macOS `/tmp` case
- [ ] All 14 globbing tests pass (`cargo test -p dvs --lib globbing`)

## Merge order

This PR targets `fix/absolute-paths-in-get`. After #138 lands, GitHub will retarget this PR to `main`.

Generated with [Claude Code](https://claude.com/claude-code)