### PR TITLE
dvs-cli: format status size with dvs::format_size

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -124,7 +124,7 @@ struct StatusRowFull<'a> {
 impl<'a> From<&'a FileMetadata> for StatusRowFull<'a> {
     fn from(m: &'a FileMetadata) -> Self {
         Self {
-            size: m.size.to_string(),
+            size: format_size(m.size),
             hash: m.hashes.blake3.as_str(),
             created_by: m.created_by.as_str(),
             add_time: m.add_time.to_string(),
@@ -376,7 +376,7 @@ fn try_main() -> Result<()> {
                         .filter_map(|fs| match &fs.detail {
                             StatusDetail::Success { status, metadata } => {
                                 let size = match metadata {
-                                    Some(m) => m.size.to_string(),
+                                    Some(m) => format_size(m.size),
                                     None => String::new(),
                                 };
                                 Some(StatusRow {


### PR DESCRIPTION
## Summary
- `dvs status` was printing raw byte counts (e.g. `10485760`) while every other CLI surface (progress bars, `get`, `add`) renders sizes via `dvs::format_size` (e.g. `10.0 MB`).
- Routes both the default `StatusRow` and the `--with-metadata` `StatusRowFull` through `format_size(m.size)`. JSON output is unchanged.

## Test plan
- [x] `cargo build -p dvs-cli` clean
- [x] `cargo clippy -p dvs-cli -- -D warnings` clean
- [x] `cargo test -p dvs --lib` passes (67 tests)
- [ ] Manual: run `dvs status` and `dvs status --with-metadata` in a repo with tracked files; sizes render as `1.0 KB` / `10.0 MB` / etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)