### PR TITLE
dvs-cli: right-align size column in status table

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -7,6 +7,7 @@ use clap::{Parser, Subcommand};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use serde_json::json;
 use tabled::Tabled;
+use tabled::settings::{Alignment, Modify, location::ByColumnName, object::Rows};
 
 use dvs::config::Config;
 use dvs::globbing::{resolve_paths_for_add, resolve_paths_for_get};
@@ -368,7 +369,10 @@ fn try_main() -> Result<()> {
                             StatusDetail::Error { .. } => None,
                         })
                         .collect();
-                    let table = tabled::Table::new(rows).to_string();
+                    let mut table = tabled::Table::new(rows);
+                    table
+                        .with(Modify::new(ByColumnName::new("size")).with(Alignment::right()))
+                        .with(Modify::new(Rows::first()).with(Alignment::left()));
                     println!("{table}");
                 } else {
                     let rows: Vec<StatusRow> = statuses
@@ -388,7 +392,10 @@ fn try_main() -> Result<()> {
                             StatusDetail::Error { .. } => None,
                         })
                         .collect();
-                    let table = tabled::Table::new(rows).to_string();
+                    let mut table = tabled::Table::new(rows);
+                    table
+                        .with(Modify::new(ByColumnName::new("size")).with(Alignment::right()))
+                        .with(Modify::new(Rows::first()).with(Alignment::left()));
                     println!("{table}");
                 }
             }


### PR DESCRIPTION
## Summary

- Right-align the values under the `size` column in `dvs status` / `dvs status --with-metadata` output, since they're numeric.
- Keep the header row left-aligned so the word `size` lines up with the left edge of the column.
- Target the column via `tabled::location::ByColumnName::new(\"size\")` rather than an index, so reordering columns later doesn't silently break the alignment.

## Before
```
| path      | status  | size   |
| big.bin   | current | 4.8 MB |
| small.csv | current | 6 B    |
```

## After
```
| path      | status  | size   |
| big.bin   | current | 4.8 MB |
| small.csv | current |    6 B |
```

## Test plan
- [x] `cargo build --release --bin dvs`
- [x] Manual: `dvs init`, add a mix of small and large files, run `dvs status --with-metadata` and confirm size values are right-aligned while `size` header is left-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)