### PR TITLE
dvs/utils: round format_size to whole units

### DIFF
--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -40,24 +40,21 @@ const TB: u64 = 1_024 * 1_024 * 1_024 * 1_024;
 pub fn format_size(bytes: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB", "PB"];
 
-    if bytes < KB {
-        return format!("{bytes} B");
+    if bytes == 0 {
+        return "0 B".to_string();
     }
 
-    let mut value = bytes as f64;
-    let mut idx = 0;
-    while value >= 1024.0 && idx + 1 < UNITS.len() {
-        value /= 1024.0;
+    // Each unit is 2^10× the previous, so ilog2(bytes) / 10 picks the unit.
+    let mut idx = ((bytes.ilog2() / 10) as usize).min(UNITS.len() - 1);
+    let mut rounded = (bytes as f64 / (1u64 << (idx * 10)) as f64).round() as u64;
+
+    // Rounding can spill into the next unit (e.g. 1023.6 KB → 1024 → 1 MB).
+    if rounded >= 1024 && idx + 1 < UNITS.len() {
         idx += 1;
+        rounded = (bytes as f64 / (1u64 << (idx * 10)) as f64).round() as u64;
     }
 
-    // If rounding to an integer would hit 1024, promote to the next unit.
-    if value.round() >= 1024.0 && idx + 1 < UNITS.len() {
-        value /= 1024.0;
-        idx += 1;
-    }
-
-    format!("{} {}", value.round() as u64, UNITS[idx])
+    format!("{rounded} {}", UNITS[idx])
 }
 
 /// Takes a human formatted byte size and convert it to the number of bytes

--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -30,12 +30,13 @@ const MB: u64 = 1_024 * 1_024;
 const GB: u64 = 1_024 * 1_024 * 1_024;
 const TB: u64 = 1_024 * 1_024 * 1_024 * 1_024;
 
-/// Formats a byte count into a human-readable string (e.g. "10.5 MB", "3 MB").
+/// Formats a byte count into a human-readable string (e.g. "10 MB", "3 MB").
 /// Uses base-1024 divisors to match `ls -h` / `du -h` output.
 ///
-/// - Whole numbers are rendered without a trailing `.0` (`1 MB`, not `1.0 MB`).
-/// - Values that would round to `1024.0 <unit>` promote to the next unit
-///   (`1048575 B` → `1 MB`, never `1024.0 KB`).
+/// Values are rounded to the nearest whole unit — a file's exact size is
+/// available via [`FileMetadata::size`] when the caller needs precision.
+/// Values that would round to `1024 <unit>` promote to the next unit
+/// (`1048575 B` → `1 MB`, never `1024 KB`).
 pub fn format_size(bytes: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB", "PB"];
 
@@ -50,18 +51,13 @@ pub fn format_size(bytes: u64) -> String {
         idx += 1;
     }
 
-    // If rounding to one decimal would hit 1024.0, promote to the next unit.
-    let rounded = (value * 10.0).round() / 10.0;
-    if rounded >= 1024.0 && idx + 1 < UNITS.len() {
-        value = rounded / 1024.0;
+    // If rounding to an integer would hit 1024, promote to the next unit.
+    if value.round() >= 1024.0 && idx + 1 < UNITS.len() {
+        value /= 1024.0;
         idx += 1;
     }
 
-    if ((value * 10.0).round() as i64) % 10 == 0 {
-        format!("{:.0} {}", value, UNITS[idx])
-    } else {
-        format!("{:.1} {}", value, UNITS[idx])
-    }
+    format!("{} {}", value.round() as u64, UNITS[idx])
 }
 
 /// Takes a human formatted byte size and convert it to the number of bytes
@@ -160,7 +156,7 @@ mod tests {
     }
 
     #[test]
-    fn format_size_drops_trailing_zero() {
+    fn format_size_is_integer_valued() {
         assert_eq!(format_size(0), "0 B");
         assert_eq!(format_size(500), "500 B");
         assert_eq!(format_size(KB), "1 KB");
@@ -168,17 +164,15 @@ mod tests {
         assert_eq!(format_size(GB), "1 GB");
         assert_eq!(format_size(TB), "1 TB");
         assert_eq!(format_size(3 * MB), "3 MB");
-    }
-
-    #[test]
-    fn format_size_keeps_fractions() {
-        assert_eq!(format_size(KB + KB / 2), "1.5 KB");
-        assert_eq!(format_size(MB + MB / 2), "1.5 MB");
+        // Fractional input rounds to nearest whole unit
+        assert_eq!(format_size(KB + KB / 2), "2 KB");
+        assert_eq!(format_size(MB + MB / 2), "2 MB");
+        assert_eq!(format_size(MB + MB / 4), "1 MB");
     }
 
     #[test]
     fn format_size_rolls_over_at_1024() {
-        // bytes just below the next unit must not render as "1024.0 <unit>"
+        // bytes just below the next unit must not render as "1024 <unit>"
         assert_eq!(format_size(MB - 1), "1 MB");
         assert_eq!(format_size(GB - 1), "1 GB");
         assert_eq!(format_size(TB - 1), "1 TB");

--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -30,19 +30,37 @@ const MB: u64 = 1_024 * 1_024;
 const GB: u64 = 1_024 * 1_024 * 1_024;
 const TB: u64 = 1_024 * 1_024 * 1_024 * 1_024;
 
-/// Formats a byte count into a human-readable string (e.g. "10.5 MB").
+/// Formats a byte count into a human-readable string (e.g. "10.5 MB", "3 MB").
 /// Uses base-1024 divisors to match `ls -h` / `du -h` output.
+///
+/// - Whole numbers are rendered without a trailing `.0` (`1 MB`, not `1.0 MB`).
+/// - Values that would round to `1024.0 <unit>` promote to the next unit
+///   (`1048575 B` → `1 MB`, never `1024.0 KB`).
 pub fn format_size(bytes: u64) -> String {
-    if bytes >= TB {
-        format!("{:.1} TB", bytes as f64 / TB as f64)
-    } else if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.1} KB", bytes as f64 / KB as f64)
+    const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB", "PB"];
+
+    if bytes < KB {
+        return format!("{bytes} B");
+    }
+
+    let mut value = bytes as f64;
+    let mut idx = 0;
+    while value >= 1024.0 && idx + 1 < UNITS.len() {
+        value /= 1024.0;
+        idx += 1;
+    }
+
+    // If rounding to one decimal would hit 1024.0, promote to the next unit.
+    let rounded = (value * 10.0).round() / 10.0;
+    if rounded >= 1024.0 && idx + 1 < UNITS.len() {
+        value = rounded / 1024.0;
+        idx += 1;
+    }
+
+    if ((value * 10.0).round() as i64) % 10 == 0 {
+        format!("{:.0} {}", value, UNITS[idx])
     } else {
-        format!("{bytes} B")
+        format!("{:.1} {}", value, UNITS[idx])
     }
 }
 
@@ -139,5 +157,30 @@ mod tests {
         assert!(parse_size("").is_err());
         assert!(parse_size("MB").is_err());
         assert!(parse_size("500XB").is_err());
+    }
+
+    #[test]
+    fn format_size_drops_trailing_zero() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(500), "500 B");
+        assert_eq!(format_size(KB), "1 KB");
+        assert_eq!(format_size(MB), "1 MB");
+        assert_eq!(format_size(GB), "1 GB");
+        assert_eq!(format_size(TB), "1 TB");
+        assert_eq!(format_size(3 * MB), "3 MB");
+    }
+
+    #[test]
+    fn format_size_keeps_fractions() {
+        assert_eq!(format_size(KB + KB / 2), "1.5 KB");
+        assert_eq!(format_size(MB + MB / 2), "1.5 MB");
+    }
+
+    #[test]
+    fn format_size_rolls_over_at_1024() {
+        // bytes just below the next unit must not render as "1024.0 <unit>"
+        assert_eq!(format_size(MB - 1), "1 MB");
+        assert_eq!(format_size(GB - 1), "1 GB");
+        assert_eq!(format_size(TB - 1), "1 TB");
     }
 }


### PR DESCRIPTION
## Summary

Simplify `format_size` output:

1. **Round to the nearest whole unit.** Sub-unit precision (`1.5 MB`, `10.4 GB`) is noise in a human-readable listing — callers that need exact bytes have `FileMetadata::size`. `format_size` is purely a display helper.
2. **Promote to the next unit** when rounding would land on `1024 <unit>`, so `1048575 B` formats as `1 MB` instead of `1024 KB`.

`parse_size` is unchanged and still accepts either integer or decimal inputs.

## Before / After

| bytes | before | after |
|---|---|---|
| `1_048_576` (1 MiB) | `1.0 MB` | `1 MB` |
| `3 * MB` | `3.0 MB` | `3 MB` |
| `MB - 1` | `1024.0 KB` | `1 MB` |
| `GB - 1` | `1024.0 MB` | `1 GB` |
| `MB + MB / 2` | `1.5 MB` | `2 MB` |
| `MB + MB / 4` | `1.3 MB` | `1 MB` |

## Test plan
- [x] `cargo test --package dvs utils::tests`
- [x] `cargo build --release --bin dvs`; manual `dvs status --with-metadata` sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)