### PR TITLE
docs(spec): remaining audit edits (errors, init/add/get/status text + R signatures, audit-log JSON, threading)

### DIFF
--- a/specs.md
+++ b/specs.md
@@ -50,12 +50,19 @@ A file in a `dvs` project can be in 3 states:
 
 ### Errors / failures
 
-All input must be evaluated, and errors as well as successes must be collated
-are reported back to the user.
+All input must be evaluated, and errors as well as successes must be collected,
+and then reported back to the user.
 
 #### CLI
 
+Error handling in CLI must be designed around the use case of being a part
+of pipelines, or non-interactive workflows. Returning error codes is necessary.
+
 #### R package
+
+Error handling in the R package assumes interactive, long-lived sessions. Thus,
+the R package must provide comprehensive information, that the end-user can
+explore.
 
 ### init
 
@@ -99,10 +106,7 @@ Options:
 
 #### Rust library
 
-- [ ] figure out the actual spec for the library, other than being the engine
-  behind both CLI and R package.
-
-Library takes a project directory and the config to save.
+Library takes a project directory and the configuration of the backend to initiate repository.
 
 #### R package
 

--- a/specs.md
+++ b/specs.md
@@ -349,15 +349,10 @@ Stored files are set read-only after writing.
 
 ### Compression
 
-Stored files are compressed with `zstd` by default. The two available compression modes are:
-
-- `zstd`: the default
-- `none`: no compression
-
-The mode is set at `init` time (via `--no-compression` on the CLI, or `compression` in the R
-package) or by editing `dvs.toml`. The compression method is recorded per-file in the metadata, so
-changing the project's compression setting does not affect retrieval of previously added files —
-`get` always reads the compression from the file's metadata.
+The two compression modes are `zstd` (default) and `none`, set at `init` time (CLI
+`--no-compression`, R `compression`) or in `dvs.toml`. The mode is recorded per-file in the
+metadata, so `get` always reads it from there — changing the project setting never affects
+previously added files.
 
 ### Audit trail
 

--- a/specs.md
+++ b/specs.md
@@ -50,8 +50,8 @@ A file in a `dvs` project can be in 3 states:
 
 ### Errors / failures
 
-All input must be evaluated, and errors as well as successes must be collected,
-and then reported back to the user.
+All input must be evaluated, and errors as well as successes must be collected
+are then reported back to the user.
 
 #### CLI
 
@@ -124,7 +124,7 @@ dvs_init(
 - `root_dir`: project root where `dvs.toml` is created (defaults to working directory)
 - `group`: Unix group to set on storage directory and files
 - `metadata_folder_name`: custom name for the metadata folder (default `.dvs`)
-- `no_compression`: disable zstd compression of stored files
+- `compression`: desired compression for the stored date (default `zstd`)
 
 Returns a list with `status = "initialized"`, invisibly.
 
@@ -186,7 +186,7 @@ It otherwise returns a list of results sorted alphabetically by path, letting us
 dvs_add(paths = character(0), message = NULL, glob = NULL, dry_run = NULL)
 ```
 
-- `files`: character vector of file paths to add (can be empty if `glob` is provided)
+- `paths`: character vector of file paths to add (can be empty if `glob` is provided)
 - `message`: optional message recorded in the metadata file.
 - `glob`: pattern to match files (same resolution rules as CLI `--glob`)
 - `dry_run`: if `TRUE`, returns what would be added without making changes
@@ -215,8 +215,6 @@ You can also do a dry run from the CLI, R package or the library that will retur
 without actually doing them.
 
 #### CLI
-
-- [ ] missing `-r, --recursive` options that `dvs status` has.
 
 ```shell
 ❯ dvs get --help
@@ -303,9 +301,9 @@ dvs_status(
 )
 ```
 
-- `paths` optional vector of files to retrieve status of
-- `status` represent the filter flags `current`, `absent`, `unsynced`.
-  When omitted, all three states are present in the returned data-frame, otherwise serval filtering status can be provided.
+- `paths` optional vector of paths files to retrieve status of
+- `status` represent the filter flags `current`, `absent`, `unsynced`
+  When omitted, all three states are present in the returned data-frame, otherwise serval filtering status can be provided
 
 Returns a data frame with one row per tracked file.
 
@@ -408,8 +406,6 @@ and operations proceed without it if that also fails.
 
 ### Parallelism
 
-- [ ] update the threads strategy here to reflect that of current `dvs2`.
-
 `add`, `get`, and `status` run file operations in parallel. You can set the `DVS_NUM_THREADS` environment
 variable to control the thread count, if the CLI and R package have not set the number
 of threads directly. If it is unset, the default is `min(available_parallelism * 4, 16)`.
@@ -430,11 +426,7 @@ the `add` operation to fail.
 
 ### Globbing
 
-<<<<<<< HEAD
 `add`, `status`, `get` accept a `--glob` flag. The resolution works the following way:
-=======
-`add`, `status`,  `get` both accept a `--glob` flag. The resolution works the following way:
->>>>>>> 6f99880 (updated spec based on slack feedback)
 
 - Explicit files: added/retrieved directly (glob ignored)
 - Explicit directories with a glob: walked and filtered by glob

--- a/specs.md
+++ b/specs.md
@@ -12,7 +12,7 @@ All configuration is handled in a `dvs.toml` config file.
 
 All CLI commands take a `--json` flag if you want to get JSON output.
 
-The Rust library must not contain anything specific to the CLI or the R package: no `miniextendr-*` dependency, no `println!`/`eprintln!`/`dbg!`. It may depend on the `log` facade but must not pull in a `log` implementer; logger setup belongs in `dvs-cli` and `dvs-rpkg`.
+The Rust library must not contain anything specific to the CLI or the R package: no `miniextendr-*` dependency, no `println!`/`eprintln!`/`dbg!`. It may depend on the `log` facade but must not pull in a `log` implementer. Logger setup belongs in `dvs-cli` and `dvs-rpkg`.
 
 ## Glossary
 
@@ -126,7 +126,7 @@ Returns a list with `status = "initialized"`, invisibly.
 ### add
 
 It only takes files as input, directories will not work unless combined with a glob. It can also take an optional
-message that will be recorded in the metadata file. Similarly, `add` must not have a recursive option; The glob mechanism is sufficient, and intentional when used.
+message that will be recorded in the metadata file. Similarly, `add` must not have a recursive option. The glob mechanism is sufficient, and intentional when used.
 
 This method follows a best-effort approach: even if some files failed to be added, it will still try to add everything
 and not stop.
@@ -187,7 +187,7 @@ dvs_add(paths = character(0), message = NULL, glob = NULL, dry_run = NULL)
 - `dry_run`: if `TRUE`, returns what would be added without making changes
 
 Returns a data frame with one row per file. Errors if no files match.
-Glob resolution uses the same rules as the CLI — see the Globbing section.
+Glob resolution uses the same rules as the CLI. See the Globbing section.
 
 Partial completion leads to a return value as a list containing two elements named `result`
 and `error`, each containing data-frames describing the failures and successes.
@@ -283,7 +283,7 @@ By default (no flags), `dvs status` shows all tracked files regardless of state.
 #### Rust library
 
 The library scans all metadata files in the project and returns a result for each one. Like `add` and `get`,
-it never errors as a whole — individual files that cannot be inspected (e.g. permission errors) are reported
+it never errors as a whole. Individual files that cannot be inspected (e.g. permission errors) are reported
 as per-file errors in the result list.
 
 #### R package
@@ -328,7 +328,7 @@ The sidecar is a JSON file with the following fields:
 - `size`: file size in bytes
 - `created_by`: system username at the time of `add`, `unknown` if it can't be found
 - `add_time`: ISO 8601 timestamp
-- `compression`: `"zstd"` or `"none"` — records how this file is stored in the backend
+- `compression`: records how this file is stored in the backend (`"zstd"` or `"none"`)
 - `message`: omitted from JSON when not provided
 
 Two metadata files are considered equal if their `hashes` and `size` match (other fields are informational).
@@ -351,8 +351,8 @@ Stored files are set read-only after writing.
 
 The two compression modes are `zstd` (default) and `none`, set at `init` time (CLI
 `--no-compression`, R `compression`) or in `dvs.toml`. The mode is recorded per-file in the
-metadata, so `get` always reads it from there — changing the project setting never affects
-previously added files.
+metadata, so `get` always reads it from there. Changing the project setting (`dvs.toml`) must not
+affect previously added files.
 
 ### Audit trail
 
@@ -398,8 +398,7 @@ Example:
 `dvs` maintains a SQLite cache at `{metadata_folder}/.cache/dvs.db` to avoid re-hashing files that haven't
 changed. Both `add` and `get` populate the cache after a successful operation, so a subsequent `status`
 check benefits from cache hits. A cache hit is determined by matching the file's `mtime` and `size`. The cache directory is
-automatically added to `.gitignore` on creation. The cache is entirely optional — if it can't be opened (e.g. corruption), `dvs` deletes it and retries once,
-and operations proceed without it if that also fails.
+automatically added to `.gitignore` on creation. The cache is optional.
 
 ### Parallelism
 

--- a/specs.md
+++ b/specs.md
@@ -48,6 +48,15 @@ A file in a `dvs` project can be in 3 states:
 
 ## In-depth spec
 
+### errors / failures
+
+- [ ] describe --fail-fast
+- [ ] do we stop processing when an error occurred?
+
+#### CLI
+
+#### R package
+
 ### init
 
 init will always error if a `dvs.toml` already exists in the target directory.
@@ -55,6 +64,10 @@ This check is local: a `dvs.toml` in a parent directory does not prevent initial
 
 On partial failure (e.g., metadata folder or storage creation fails after `dvs.toml` is written),
 init attempts best-effort cleanup of local artifacts (`dvs.toml` and, if it didn't exist beforehand, the metadata folder) so that a retry is possible.
+
+A storage directory or backend is bound to one dvs repository.
+
+`metadata_folder_name` is omitted from `dvs.toml` if not specified.
 
 #### CLI
 
@@ -86,12 +99,21 @@ Options:
 
 #### Rust library
 
+- [ ] figure out the actual spec for the library, other than being the engine
+  behind both CLI and R package.
+
 Library takes a project directory and the config to save.
 
 #### R package
 
 ```r
-dvs_init(storage_path, root_dir = ".", group = NULL, metadata_folder_name = NULL, no_compression = FALSE)
+dvs_init(
+  storage_path,
+  root_dir = NULL,
+  group = NULL,
+  metadata_folder_name = NULL,
+  compression = c("zstd", "none")
+)
 ```
 
 - `storage_path`: where the data will be stored (required, same as CLI's `<PATH>`)
@@ -100,9 +122,14 @@ dvs_init(storage_path, root_dir = ".", group = NULL, metadata_folder_name = NULL
 - `metadata_folder_name`: custom name for the metadata folder (default `.dvs`)
 - `no_compression`: disable zstd compression of stored files
 
-Returns a list with `status = "initialized"`.
+Returns a list with `status = "initialized"`, invisibly.
 
 ### add
+
+- [ ] does not support folder as an argument
+- [ ] does not support overriding compression of the storage data, e.g. if repo
+  is not set to use compression, we cannot add one file that selectively is
+  then compressed.
 
 It only takes files as input, directories will not work unless combined with a glob. It can also take an optional
 message that will be recorded in the metadata file.
@@ -121,10 +148,12 @@ Symlinks are resolved before adding. If a symlink target resolves to a path outs
 Each `add` operation is atomic: the storage write and metadata update either both succeed or both roll back. A
 failure writing to storage will not leave behind a partial metadata file, and vice versa.
 
-You can also do a dry run from the CLI or the library that will return the outcome that would have happened  for each file but 
+You can also do a dry run from the CLI,the library, or R package that will return the outcome that would have happened for each file but
 without actually doing them.
 
 #### CLI
+
+- [ ] missing `-r, --recursive` options that `dvs status` has.
 
 ```shell
 ❯ dvs add --help
@@ -147,7 +176,7 @@ Options:
 You can run `dvs add *.csv` and it will be expanded by your shell before calling `dvs`.
 To ensure globs are consistent with the R package, you can use the `--glob` parameter which will be expanded by the library.
 
-This will exit with `1` if one or more files could not be added to the storage (file does not exist, no permissions etc).
+This will exit with `1` if one or more files could not be added to the storage (file does not exist, no permissions, etc).
 
 #### Rust library
 
@@ -157,16 +186,19 @@ It otherwise returns a list of results sorted alphabetically by path, letting us
 #### R package
 
 ```r
-dvs_add(files = character(0), message, glob = NULL, dry_run = FALSE)
+dvs_add(paths = character(0), message = NULL, glob = NULL, dry_run = NULL)
 ```
 
 - `files`: character vector of file paths to add (can be empty if `glob` is provided)
-- `message`: optional message recorded in the metadata file. Omit or pass `NULL` to skip
+- `message`: optional message recorded in the metadata file.
 - `glob`: pattern to match files (same resolution rules as CLI `--glob`)
 - `dry_run`: if `TRUE`, returns what would be added without making changes
 
 Returns a data frame with one row per file. Errors if no files match.
 Glob resolution uses the same rules as the CLI — see the Globbing section.
+
+- [ ] Partial completion results in a list containing two elements named `result`
+and `error`, each containing data-frames describing the failures and successes.
 
 ### get
 
@@ -182,10 +214,12 @@ is deleted and the operation fails for that file.
 Users can use `get` with specific paths or globs. In practice those will be ran on the metadata folder rather
 than the actual project, to know what to pull but the resolution works the same way as `add`.
 
-You can also do a dry run from the CLI or the library that will return the outcome that would have happened for each file but
+You can also do a dry run from the CLI, R package or the library that will return the outcome that would have happened for each file but
 without actually doing them.
 
 #### CLI
+
+- [ ] missing `-r, --recursive` options that `dvs status` has.
 
 ```shell
 ❯ dvs get --help
@@ -207,13 +241,14 @@ Options:
 This will exit with `1` if one or more files could not be retrieved.
 
 #### Rust library
+
 The library automatically sets up parallelism and the only error it can return is if it couldn't set up the threadpool.
 It otherwise returns a list of results sorted alphabetically by path, letting users decide what to do with each.
 
 #### R package
 
 ```r
-dvs_get(files = character(0), glob = NULL, dry_run = FALSE)
+dvs_get(paths = character(0), glob = NULL, dry_run = NULL)
 ```
 
 - `files`: character vector of file paths to retrieve (can be empty if `glob` is provided)
@@ -222,7 +257,12 @@ dvs_get(files = character(0), glob = NULL, dry_run = FALSE)
 
 Returns a data frame with one row per file. Errors if no files match.
 
+- [ ] Partial completion results in a list containing two elements named `result`
+and `error`, each containing data-frames describing the failures and successes.
+
 ### status
+
+- [ ] does not show "untracked" files even when a folder is provided
 
 This returns the status (mentioned in the high level overview above) of the tracked files in the project.
 
@@ -260,10 +300,16 @@ as per-file errors in the result list.
 #### R package
 
 ```r
-dvs_status(current = FALSE, absent = FALSE, unsynced = FALSE)
+dvs_status(
+  paths = character(0),
+  recursive = NULL,
+  status = c("current", "absent", "unsynced")
+)
 ```
 
-- `current`, `absent`, `unsynced`: filter flags. When all are `FALSE` (default), all tracked files are returned. When one or more are `TRUE`, only files matching those states are returned. Errors are always included.
+- `paths` optional vector of files to retrieve status of
+- `status` represent the filter flags `current`, `absent`, `unsynced`.
+  When all are `FALSE` (default), all tracked files are returned. When one or more are `TRUE`, only files matching those states are returned. Errors are always included.
 
 Returns a data frame with one row per tracked file.
 
@@ -317,7 +363,6 @@ prevents partial blobs from appearing in storage mapping to an expected file.
 
 Stored files are set read-only after writing.
 
-
 ### Audit trail
 
 Every `add` operation is logged to an append-only audit file (`audit.log.jsonl`) in the storage directory. Each
@@ -326,11 +371,36 @@ entry records:
 - `operation_id`: a UUID grouping all files from one `add` invocation
 - `timestamp`: unix seconds
 - `user`: the system username of whoever ran the command
-- `file`: path and hashes of the added file
 - `action`: currently only `add`
+
+`add` is an object that contains
+
+- `file`: path and hashes of the added file
+- `compression`: `"zstd"` or `"none"`, see add section above
 
 The audit log is protected by a mutex so a single `dvs` process cannot corrupt it but there is no protection against
 multiple processes appending logs.
+
+Example:
+
+```json
+{
+  "operation_id": "93ca9155-b767-47e8-b433-a110f5943212",
+  "timestamp": 1776959650,
+  "user": "elea",
+  "action": {
+    "add": {
+      "file": {
+        "path": "data/derived/many34.csv",
+        "hashes": {
+          "blake3": "55539acdd1e0617c9180f8a593aeda480b7fab415faef16596f25098908b8487"
+        }
+      },
+      "compression": "zstd"
+    }
+  }
+}
+```
 
 ### Hash cache
 
@@ -342,10 +412,17 @@ and operations proceed without it if that also fails.
 
 ### Parallelism
 
+- [ ] update the threads strategy here to reflect that of current `dvs2`.
+
 `add`, `get`, and `status` run file operations in parallel. You can set the `DVS_NUM_THREADS` environment
 variable to control the thread count. If it is unset, the default is `min(available_parallelism * 4, 16)`.
 If it is set to a positive integer, the override is capped at 32. In both cases the final thread count is
 clamped to the number of files being processed.
+
+#### R package
+
+The environment variable `DVS_NUM_THREADS` takes precedence over the threadpool
+size set by the R package.
 
 ### Gitignore
 

--- a/specs.md
+++ b/specs.md
@@ -48,10 +48,10 @@ A file in a `dvs` project can be in 3 states:
 
 ## In-depth spec
 
-### errors / failures
+### Errors / failures
 
-- [ ] describe --fail-fast
-- [ ] do we stop processing when an error occurred?
+All input must be evaluated, and errors as well as successes must be collated
+are reported back to the user.
 
 #### CLI
 
@@ -126,13 +126,8 @@ Returns a list with `status = "initialized"`, invisibly.
 
 ### add
 
-- [ ] does not support folder as an argument
-- [ ] does not support overriding compression of the storage data, e.g. if repo
-  is not set to use compression, we cannot add one file that selectively is
-  then compressed.
-
 It only takes files as input, directories will not work unless combined with a glob. It can also take an optional
-message that will be recorded in the metadata file.
+message that will be recorded in the metadata file. Similarly, `add` must not have a recursive option; The glob mechanism is sufficient, and intentional when used.
 
 This method follows a best-effort approach: even if some files failed to be added, it will still try to add everything
 and not stop.
@@ -152,8 +147,6 @@ You can also do a dry run from the CLI,the library, or R package that will retur
 without actually doing them.
 
 #### CLI
-
-- [ ] missing `-r, --recursive` options that `dvs status` has.
 
 ```shell
 ❯ dvs add --help
@@ -262,9 +255,8 @@ and `error`, each containing data-frames describing the failures and successes.
 
 ### status
 
-- [ ] does not show "untracked" files even when a folder is provided
-
-This returns the status (mentioned in the high level overview above) of the tracked files in the project.
+This returns the status (mentioned in the high level overview above)
+ of the tracked files in the project.
 
 #### CLI
 
@@ -309,7 +301,7 @@ dvs_status(
 
 - `paths` optional vector of files to retrieve status of
 - `status` represent the filter flags `current`, `absent`, `unsynced`.
-  When all are `FALSE` (default), all tracked files are returned. When one or more are `TRUE`, only files matching those states are returned. Errors are always included.
+  When omitted, all three states are present in the returned data-frame, otherwise serval filtering status can be provided.
 
 Returns a data frame with one row per tracked file.
 
@@ -433,7 +425,11 @@ the `add` operation to fail.
 
 ### Globbing
 
+<<<<<<< HEAD
 `add`, `status`, `get` accept a `--glob` flag. The resolution works the following way:
+=======
+`add`, `status`,  `get` both accept a `--glob` flag. The resolution works the following way:
+>>>>>>> 6f99880 (updated spec based on slack feedback)
 
 - Explicit files: added/retrieved directly (glob ignored)
 - Explicit directories with a glob: walked and filtered by glob

--- a/specs.md
+++ b/specs.md
@@ -190,7 +190,7 @@ dvs_add(paths = character(0), message = NULL, glob = NULL, dry_run = NULL)
 Returns a data frame with one row per file. Errors if no files match.
 Glob resolution uses the same rules as the CLI — see the Globbing section.
 
-- [ ] Partial completion results in a list containing two elements named `result`
+Partial completion leads to a return value as a list containing two elements named `result`
 and `error`, each containing data-frames describing the failures and successes.
 
 ### get
@@ -250,7 +250,7 @@ dvs_get(paths = character(0), glob = NULL, dry_run = NULL)
 
 Returns a data frame with one row per file. Errors if no files match.
 
-- [ ] Partial completion results in a list containing two elements named `result`
+Partial completion leads to a return value as a list containing two elements named `result`
 and `error`, each containing data-frames describing the failures and successes.
 
 ### status
@@ -407,7 +407,8 @@ and operations proceed without it if that also fails.
 - [ ] update the threads strategy here to reflect that of current `dvs2`.
 
 `add`, `get`, and `status` run file operations in parallel. You can set the `DVS_NUM_THREADS` environment
-variable to control the thread count. If it is unset, the default is `min(available_parallelism * 4, 16)`.
+variable to control the thread count, if the CLI and R package have not set the number
+of threads directly. If it is unset, the default is `min(available_parallelism * 4, 16)`.
 If it is set to a positive integer, the override is capped at 32. In both cases the final thread count is
 clamped to the number of files being processed.
 

--- a/specs.md
+++ b/specs.md
@@ -50,8 +50,7 @@ A file in a `dvs` project can be in 3 states:
 
 ### Errors / failures
 
-All input must be evaluated, and errors as well as successes must be collected
-are then reported back to the user.
+All input must be evaluated, and errors as well as successes must be collected and then reported back to the user.
 
 #### CLI
 
@@ -71,10 +70,6 @@ This check is local: a `dvs.toml` in a parent directory does not prevent initial
 
 On partial failure (e.g., metadata folder or storage creation fails after `dvs.toml` is written),
 init attempts best-effort cleanup of local artifacts (`dvs.toml` and, if it didn't exist beforehand, the metadata folder) so that a retry is possible.
-
-A storage directory or backend is bound to one dvs repository.
-
-`metadata_folder_name` is omitted from `dvs.toml` if not specified.
 
 #### CLI
 
@@ -124,7 +119,7 @@ dvs_init(
 - `root_dir`: project root where `dvs.toml` is created (defaults to working directory)
 - `group`: Unix group to set on storage directory and files
 - `metadata_folder_name`: custom name for the metadata folder (default `.dvs`)
-- `compression`: desired compression for the stored date (default `zstd`)
+- `compression`: desired compression for the stored data (default `zstd`)
 
 Returns a list with `status = "initialized"`, invisibly.
 
@@ -246,7 +241,7 @@ It otherwise returns a list of results sorted alphabetically by path, letting us
 dvs_get(paths = character(0), glob = NULL, dry_run = NULL)
 ```
 
-- `files`: character vector of file paths to retrieve (can be empty if `glob` is provided)
+- `paths`: character vector of file paths to retrieve (can be empty if `glob` is provided)
 - `glob`: pattern to match files in the metadata folder (same resolution rules as CLI `--glob`)
 - `dry_run`: if `TRUE`, returns what would be retrieved without making changes
 
@@ -346,16 +341,23 @@ and the remaining characters as the filename.
 For example, a file with blake3 hash `af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262` is stored at
 `<storage-path>/af/1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262`.
 
-Files in storage are compressed with zstd by default. The two compression modes are `zstd` and `none`
-(set at `init` time via `--no-compression`, or by editing `dvs.toml`). The compression method is recorded
-per-file in the metadata, so changing the project's compression setting does not affect retrieval of
-previously added files — `get` always reads the compression from the file's metadata.
-
 Writes to storage are atomic: data is first written to a temporary file (with a `.tmp` extension) in the
 same directory, then renamed into place. Since rename is atomic on POSIX within the same filesystem, this
 prevents partial blobs from appearing in storage mapping to an expected file.
 
 Stored files are set read-only after writing.
+
+### Compression
+
+Stored files are compressed with `zstd` by default. The two available compression modes are:
+
+- `zstd`: the default
+- `none`: no compression
+
+The mode is set at `init` time (via `--no-compression` on the CLI, or `compression` in the R
+package) or by editing `dvs.toml`. The compression method is recorded per-file in the metadata, so
+changing the project's compression setting does not affect retrieval of previously added files —
+`get` always reads the compression from the file's metadata.
 
 ### Audit trail
 
@@ -370,7 +372,7 @@ entry records:
 `add` is an object that contains
 
 - `file`: path and hashes of the added file
-- `compression`: `"zstd"` or `"none"`, see add section above
+- `compression`: `"zstd"` or `"none"`, see the Compression section
 
 The audit log is protected by a mutex so a single `dvs` process cannot corrupt it but there is no protection against
 multiple processes appending logs.
@@ -414,8 +416,8 @@ clamped to the number of files being processed.
 
 #### R package
 
-The environment variable `DVS_NUM_THREADS` takes precedence over the threadpool
-size set by the R package.
+The threadpool size set directly by the R package takes precedence over the
+`DVS_NUM_THREADS` environment variable.
 
 ### Gitignore
 


### PR DESCRIPTION
REPURPOSED PR: This is now a PR providing amendments to the `specs.md` that are broader in scope, and R package specific.

<details>
<summary><h3>AI-written details</h3></summary>

## Status: residual after Wave 1 splits

This PR was the original "spec audit april" pass (178 +/45 -). It has been carved up into focused PRs; what remains here is the content that's either harder to verify against current code or still blocked on author decisions.

### Already extracted
| Topic | Now in |
|---|---|
| Drop stale `lib.rs` mod comment (the only non-spec change) | #197 |
| Drop `untracked` from file-state model (4 → 3 states) | #199 |
| High-level conventions: paths, NULL defer | #200 |
| Misc cleanups: whitespace, capitalization, three-cmd glob | #201 |
| Refresh CLI `--help` blocks for init/add/get/status | #202 |
| ui trace cleanup (was hitchhiking on #170) | #198 |

### Remaining here
- **Errors / failures** new section, including empty `#### CLI` and `#### R package` subsections — **blocked**: the empty subsections need content before this can land.
- **init**: "A storage directory or backend is bound to one dvs repository" + `metadata_folder_name` omitted when default; Library section prose; `dvs_init` R signature change (`root_dir = NULL`, `compression = c("zstd", "none")`, drops `no_compression`); return prose update.
- **add**: "must not have a recursive option" rule; dry-run prose to mention R package; `dvs_add` R signature (`paths`, `dry_run = NULL`); partial-completion contract paragraph.
- **get**: dry-run prose mentions R package; `dvs_get` R signature (`paths`, `dry_run = NULL`); partial-completion contract paragraph.
- **status**: prose line break; `dvs_status` R signature (`paths`, `recursive`, `status` filter vector); bullet rewrite.
- **Audit trail**: nested `add` object shape (`file` + `compression`); worked JSON example.
- **Parallelism**: clarify env var vs explicit thread count; new `#### R package` subsection — **partially blocked**: tied to the threading-strategy TODO at the original L419.

### Follow-up needed before this can merge
- [ ] Fill in the two empty subsections under "Errors / failures"
- [ ] Resolve the parallelism / threading strategy TODO
- [ ] Validate every R signature against the actual exported wrapper in `dvs-rpkg/R/dvs-commands.R` after #170, #193, #154 land — the signatures here are aspirational

## Test plan
- [ ] specs.md renders cleanly on GitHub once the above gaps are filled
- [ ] R signatures match the actual exports after the dependent feature PRs land

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>