### PR TITLE
dvs: fix panic in status/add/get for empty repos

### DIFF
--- a/dvs/src/files/add.rs
+++ b/dvs/src/files/add.rs
@@ -97,6 +97,9 @@ pub fn add_files(
     on_file_start: Option<&OnFileStart>,
 ) -> Result<Vec<AddResult>> {
     let matched_paths = paths.validate_for_add(&files);
+    if matched_paths.is_empty() {
+        return Ok(Vec::new());
+    }
     let pool = get_threadpool(matched_paths.len())?;
     let cache = try_open_cache(paths);
     let operation_id = Uuid::new_v4();

--- a/dvs/src/files/get.rs
+++ b/dvs/src/files/get.rs
@@ -120,6 +120,9 @@ pub fn get_files(
     on_file_start: Option<&OnFileStart>,
 ) -> Result<Vec<GetResult>> {
     let matched_paths = paths.validate_for_get(&files);
+    if matched_paths.is_empty() {
+        return Ok(Vec::new());
+    }
     let pool = get_threadpool(matched_paths.len())?;
     let cache = try_open_cache(paths);
 

--- a/dvs/src/files/status.rs
+++ b/dvs/src/files/status.rs
@@ -147,6 +147,10 @@ pub fn get_status(paths: &DvsPaths, filter: Option<&StatusFilter>) -> Result<Vec
         .map(|e| e.into_path())
         .collect();
 
+    if entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
     let pool = get_threadpool(entries.len())?;
 
     let mut results: Vec<FileStatus> = pool.install(|| {
@@ -337,6 +341,16 @@ mod tests {
                 StatusDetail::Error { error } => panic!("unexpected error: {error}"),
             }
         }
+    }
+
+    #[test]
+    fn get_status_returns_empty_vec_for_repo_with_no_tracked_files() {
+        let (_tmp, root) = create_temp_git_repo();
+        let (config, _dvs_dir) = init_dvs_repo(&root);
+        let paths = make_paths(&root, &config);
+
+        let statuses = get_status(&paths, None).unwrap();
+        assert!(statuses.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `dvs status` (and `dvs add`/`dvs get` with no matches) panicked in debug builds because `get_threadpool` asserts it is never called with zero work items, but all three callers could pass zero when the repo had no tracked files or no matching paths.
- Fix: add an `if … .is_empty() { return Ok(Vec::new()); }` guard at each of the three callsites (`status.rs`, `add.rs`, `get.rs`) before `get_threadpool` is called. The `debug_assert_ne!` contract is kept intact.
- Adds a regression test: `get_status_returns_empty_vec_for_repo_with_no_tracked_files`.

## Test plan

- [ ] `just test` passes (68 tests, 0 failures)
- [ ] Manual repro: `dvs init <storage> && dvs status` in a fresh repo exits cleanly with "No tracked files" and no panic
- [ ] New regression test `get_status_returns_empty_vec_for_repo_with_no_tracked_files` covers the empty-repo path

🤖 Generated with [Claude Code](https://claude.com/claude-code)