### PR TITLE
dvs-cli: prefix top-level errors with "Error:"

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -461,7 +461,7 @@ fn try_main() -> Result<()> {
 
 fn main() {
     if let Err(e) = try_main() {
-        eprintln!("{e:?}");
+        eprintln!("Error: {e}");
         ::std::process::exit(1)
     }
 }


### PR DESCRIPTION
## Summary

- `main()` was printing fatal errors with `{e:?}` (Debug format), producing raw anyhow output with no prefix
- Changed to `eprintln!("Error: {e}")` so all failures consistently surface as `Error: <message>`
- Per-file error messages in `add`, `status`, and `get` already contained "Error" and were left unchanged

## Test plan

- [ ] `dvs add` on a file outside a DVS repo → `Error: Not in a DVS repository`
- [ ] `dvs get` with no files → `Error: No files to get`
- [ ] `dvs init` with storage path inside the repo → `Error: The given storage path is within the repository.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)