### PR TITLE
rpkg: surface status/get summary messages in R console

### DIFF
--- a/dvs-rpkg/R/dvs-commands.R
+++ b/dvs-rpkg/R/dvs-commands.R
@@ -44,6 +44,11 @@ dvs_add <- function(
     progress_callback = progress_callback
   )
 
+  error_rows <- result[!is.na(result[["error"]]), ]
+  for (i in seq_len(nrow(error_rows))) {
+    warning("Error adding ", error_rows$path[i], ": ", error_rows$error[i], call. = FALSE)
+  }
+
   if (!is.null(result$size)) {
     result$size <- new_dvs_bytes(result$size)
   }
@@ -74,6 +79,22 @@ dvs_status <- function(
       status = status
     )
 
+  if (nrow(status_data_frame) == 0) {
+    if (setequal(status, c("current", "absent", "unsynced"))) {
+      message("No tracked files")
+    } else {
+      message("No tracked files matching the filter")
+    }
+  } else {
+    error_rows <- status_data_frame[!is.na(status_data_frame[["error"]]), ]
+    for (i in seq_len(nrow(error_rows))) {
+      warning(
+        "Error getting status for ", error_rows$path[i], ": ", error_rows$error[i],
+        call. = FALSE
+      )
+    }
+  }
+
   if (!is.null(status_data_frame$size)) {
     status_data_frame$size <- new_dvs_bytes(status_data_frame$size)
   }
@@ -100,6 +121,18 @@ dvs_get <- function(paths = character(0), glob = NULL, recursive = NULL, dry_run
     dry_run = dry_run,
     progress_callback = progress_callback
   )
+
+  error_rows <- get_data_frame[!is.na(get_data_frame[["error"]]), ]
+  for (i in seq_len(nrow(error_rows))) {
+    warning("Error: ", error_rows$path[i], " - ", error_rows$error[i], call. = FALSE)
+  }
+
+  copied_mask <- !is.na(get_data_frame[["outcome"]]) & get_data_frame[["outcome"]] == "copied"
+  total_files <- sum(copied_mask)
+  if (total_files > 0) {
+    total_bytes <- sum(get_data_frame[["size"]][copied_mask])
+    message("Total: ", total_files, " files, ", format_byte_size(total_bytes))
+  }
 
   if (!is.null(get_data_frame$size)) {
     get_data_frame$size <- new_dvs_bytes(get_data_frame$size)

--- a/dvs-rpkg/R/dvs-commands.R
+++ b/dvs-rpkg/R/dvs-commands.R
@@ -44,11 +44,6 @@ dvs_add <- function(
     progress_callback = progress_callback
   )
 
-  error_rows <- result[!is.na(result[["error"]]), ]
-  for (i in seq_len(nrow(error_rows))) {
-    warning("Error adding ", error_rows$path[i], ": ", error_rows$error[i], call. = FALSE)
-  }
-
   if (!is.null(result$size)) {
     result$size <- new_dvs_bytes(result$size)
   }
@@ -85,14 +80,6 @@ dvs_status <- function(
     } else {
       message("No tracked files matching the filter")
     }
-  } else {
-    error_rows <- status_data_frame[!is.na(status_data_frame[["error"]]), ]
-    for (i in seq_len(nrow(error_rows))) {
-      warning(
-        "Error getting status for ", error_rows$path[i], ": ", error_rows$error[i],
-        call. = FALSE
-      )
-    }
   }
 
   if (!is.null(status_data_frame$size)) {
@@ -121,11 +108,6 @@ dvs_get <- function(paths = character(0), glob = NULL, recursive = NULL, dry_run
     dry_run = dry_run,
     progress_callback = progress_callback
   )
-
-  error_rows <- get_data_frame[!is.na(get_data_frame[["error"]]), ]
-  for (i in seq_len(nrow(error_rows))) {
-    warning("Error: ", error_rows$path[i], " - ", error_rows$error[i], call. = FALSE)
-  }
 
   copied_mask <- !is.na(get_data_frame[["outcome"]]) & get_data_frame[["outcome"]] == "copied"
   total_files <- sum(copied_mask)


### PR DESCRIPTION
<!-- TODO: leading paragraph -->

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
The dvs CLI prints two informational lines that the R package was silently dropping:
- `println!("No tracked files")` / `"...matching the filter"` from `dvs status` when the result is empty.
- `println!("Total: N files, X")` from `dvs get` summarizing copied files.

`dvs-rpkg/R/dvs-commands.R` (+15 lines, only file touched) now mirrors both:
- `dvs_status()` emits `message("No tracked files")` or `message("No tracked files matching the filter")` depending on whether all three states or a subset is requested.
- `dvs_get()` emits `message("Total: <N> files, <size>")` whenever at least one file was actually copied.

Uses `message()` (not `warning()`) so output reaches the console without being treated as a condition: `tryCatch` / `withCallingHandlers` `warning =` handlers don't fire on it, interactive and non-interactive sessions both see it.

Per-file errors are *not* surfaced via `warning()` — they're already rows in the returned data frame, which is the contract the rest of `dvs_*` follows. Deliberate narrowing from an earlier draft that warned per row.

## Test plan
- [ ] `devtools::test('dvs-rpkg')` passes
- [ ] `dvs_status()` against an empty repo prints `No tracked files` and returns the empty tibble
- [ ] `dvs_status(status = "absent")` against an empty filter result prints `...matching the filter`
- [ ] `dvs_get(...)` after at least one copy prints `Total: N files, <human-size>`

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>