### PR TITLE
chore: run fmt-all

### DIFF
--- a/dvs-rpkg/src/rust/lib.rs
+++ b/dvs-rpkg/src/rust/lib.rs
@@ -27,8 +27,8 @@ use dvs::globbing::{resolve_paths_for_add, resolve_paths_for_get};
 use dvs::init::init;
 use dvs::paths::DvsPaths;
 use dvs::{
-    Compression, FileMetadata, FileProgress, FileStatus, GetResult, Hashes, Status,
-    StatusDetail, StatusFilter, add_files, get_files, get_status, set_num_threads,
+    Compression, FileMetadata, FileProgress, FileStatus, GetResult, Hashes, Status, StatusDetail,
+    StatusFilter, add_files, get_files, get_status, set_num_threads,
 };
 
 use cli_progress::CliProgressBar;


### PR DESCRIPTION
## Summary

- Runs `just fmt-all` (`cargo fmt` on both `dvs` and `dvs-rpkg`) from `origin/main`.
- One file changed: `dvs-rpkg/src/rust/lib.rs` — two import lines reformatted to fit within the line-length limit.

## Test plan

- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)