### PR TITLE
chore: remove .dvs/, dvs.toml, .storage from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,7 @@ dvsR/2026-*.txt
 # Archived crates (server/daemon moved here)
 archived-crates.zip
 
-.dvs/
-dvs.toml
-.storage
-# markdown rendering artefacts 
+# markdown rendering artefacts
 ui/*_files
 /README.md
 dvs_repo_*


### PR DESCRIPTION
## Summary

- Removes `.dvs/`, `dvs.toml`, and `.storage` from `.gitignore` so these paths are no longer ignored by git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)