### PR TITLE
chore: track .alx/ project config and exclude .alexandria-cli from workspace

### DIFF
--- a/.alx/.gitignore
+++ b/.alx/.gitignore
@@ -1,0 +1,1 @@
+user.yaml

--- a/.alx/config.yaml
+++ b/.alx/config.yaml
@@ -1,0 +1,3 @@
+project_links:
+- remote_url: https://alx.dev.a2-ai.cloud/api
+  project_id: 5385c7c6-431b-4a31-963b-b180a7367969

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 members = ["dvs", "dvs-cli"]
-exclude = [".alexandria-cli"]
 resolver = "2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["dvs", "dvs-cli"]
+exclude = [".alexandria-cli"]
 resolver = "2"
 
 [profile.release]


### PR DESCRIPTION
## Summary

- `.alx/.gitignore` ignores per-developer `.alx/user.yaml`.
- `.alx/config.yaml` pins this repo to its alx project on `alx.dev.a2-ai.cloud` (project_id `5385c7c6-431b-4a31-963b-b180a7367969`). Required by the upcoming `just ui-publish` flow.
- `Cargo.toml` adds `exclude = [".alexandria-cli"]` so a local alx CLI clone alongside dvs2 doesn't get pulled into the cargo workspace via `cargo metadata`.

## Test plan

- [x] `cargo check --workspace` succeeds with the exclude in place
- [x] `git add .alx/` only tracks `.gitignore` + `config.yaml`; `user.yaml` is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)