### PR TITLE
chore(ui): rollup of UI test conventions, say()/PS4 traces, print(width=Inf), and just ui-publish

### DIFF
--- a/justfile
+++ b/justfile
@@ -164,3 +164,58 @@ rpkg-bindgen-cli:
 
 ci: fmt-check clippy check-std-fs test
     @echo "All CI checks passed!"
+
+# ============================================================================
+# UI test outputs (publish to alx project in .alx/config.yaml)
+# ============================================================================
+
+# Names correspond to ui/main_<NAME>.sh (and ui/main.sh for "main").
+# Each name has matching ui/output/ui-<NAME>.html and alx topic ui-<NAME>.
+ui_names := "main status progress parallel recursive"
+
+# Run all ui/main*.sh scripts and capture each log into /tmp/ui-<NAME>.log
+ui-run:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    bash ui/cleanup.sh >/dev/null 2>&1 || true
+    for name in {{ui_names}}; do
+        if [[ "$name" == "main" ]]; then script="ui/main.sh"; else script="ui/main_${name}.sh"; fi
+        log="/tmp/ui-${name}.log"
+        echo "Running ${script} → ${log}"
+        bash "$script" > "$log" 2>&1 || echo "  WARN: ${script} exited nonzero (log captured anyway)"
+    done
+
+# Wrap each /tmp/ui-<NAME>.log into ui/output/ui-<NAME>.html
+ui-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p ui/output
+    for name in {{ui_names}}; do
+        log="/tmp/ui-${name}.log"
+        out="ui/output/ui-${name}.html"
+        if [[ ! -f "$log" ]]; then echo "skipping ${name} (no ${log})"; continue; fi
+        {
+            printf '<!DOCTYPE html>\n<html><head><meta charset="utf-8"><title>ui-%s</title>\n' "$name"
+            printf '<style>body{font-family:ui-monospace,Menlo,Consolas,monospace;background:#1e1e1e;color:#e6e6e6;padding:1rem;margin:0}pre{white-space:pre-wrap;word-wrap:break-word;font-size:20px;line-height:1.45}h1{color:#9ecbff;font-family:system-ui,sans-serif;font-size:1.5rem;margin:0 0 1rem}</style></head><body>\n'
+            printf '<h1>ui-%s</h1>\n<pre>' "$name"
+            sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' "$log"
+            printf '</pre></body></html>\n'
+        } > "$out"
+        echo "wrote ${out}"
+    done
+
+# Publish ui/output/ui-<NAME>.html to alx with each script as source attachment
+ui-publish-only:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    for name in {{ui_names}}; do
+        if [[ "$name" == "main" ]]; then script="ui/main.sh"; else script="ui/main_${name}.sh"; fi
+        out="ui/output/ui-${name}.html"
+        if [[ ! -f "$out" ]]; then echo "skipping ${name} (no ${out})"; continue; fi
+        echo "--- alx publish ui-${name} ---"
+        alx publish "$out" -S "$script" -S ui/helpers.sh -t "ui-${name}" \
+            --overwrite --skip-warnings --no-prompt 2>&1 | tail -8
+    done
+
+# Full pipeline: run scripts → render HTML → publish to alx
+ui-publish: ui-run ui-render ui-publish-only

--- a/ui/helpers.sh
+++ b/ui/helpers.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Use '> ' as the xtrace prefix instead of bash's default '+ '.
+PS4='> '
+
+# Echo without leaving an xtrace line for the echo itself.
+# Use for blank-line separators and "=== section ===" headers.
+say() { { set +x; } 2>/dev/null; echo "$@"; { set -x; } 2>/dev/null; }
+
 print_eval_rscript() {
   tee /dev/stderr | Rscript -
 }
@@ -61,6 +68,20 @@ mkfiles() {
     padded="$(printf '%0*d' "$width" "$i")"
     head -c "$bytes" /dev/urandom > "$dir/file_${padded}.bin"
   done
+  set -x
+}
+
+# Create a single random-content file at PATH (default 1KB).
+# Wraps `head -c … /dev/urandom > path` so the path shows up in `set -x` traces
+# rather than ten identical "head -c 1024 /dev/urandom" lines.
+mkrandfile() {
+  { set +x; } 2>/dev/null
+  local path="${1:?path is required}"
+  local size="${2:-1K}"
+  local bytes
+  bytes="$(size_to_bytes "$size")"
+  mkdir -p "$(dirname "$path")"
+  head -c "$bytes" /dev/urandom > "$path"
   set -x
 }
 

--- a/ui/main.sh
+++ b/ui/main.sh
@@ -12,7 +12,9 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
 DVS_REPO_CLI="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_cli_XXX)"
-DVS_STORAGE_CLI="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_cli_XXX)"
+RUN_SUFFIX="${DVS_REPO_CLI##*_}"
+DVS_STORAGE_CLI="$SCRIPT_DIR/dvs_storage_cli_$RUN_SUFFIX"
+mkdir "$DVS_STORAGE_CLI"
 
 # region: INIT
 
@@ -22,8 +24,9 @@ dvs init "$DVS_STORAGE_CLI"
 
 ls -a "$DVS_REPO_CLI" "$DVS_STORAGE_CLI"
 
-DVS_REPO_RPKG="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_rpkg_XXX)"
-DVS_STORAGE_RPKG="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_rpkg_XXX)"
+DVS_REPO_RPKG="$SCRIPT_DIR/dvs_repo_rpkg_$RUN_SUFFIX"
+DVS_STORAGE_RPKG="$SCRIPT_DIR/dvs_storage_rpkg_$RUN_SUFFIX"
+mkdir "$DVS_REPO_RPKG" "$DVS_STORAGE_RPKG"
 
 cd "$DVS_REPO_RPKG"
 

--- a/ui/main.sh
+++ b/ui/main.sh
@@ -5,6 +5,8 @@ set -euox pipefail
 # prints the line in script that errors
 trap 'printf "ERROR at %s:%d\n" "${BASH_SOURCE[0]}" "$LINENO" >&2' ERR
 
+echo "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
@@ -81,10 +83,6 @@ dvs_status()
 
 EOF
 
-# TODO:
-#   [ ] make tibble a Suggests, and _impl post-fix the dvs_* from Rust stuff
-#   [ ] truncate the hash
-
 # # Compare dvs.toml (created by init)
 # diff "${DVS_REPO_CLI}"/dvs.toml "${DVS_REPO_RPKG}"/dvs.toml
 
@@ -96,5 +94,5 @@ EOF
 
 
 
-
+w
 printf '\nCleanup: bash %s/cleanup.sh\n' "$SCRIPT_DIR"

--- a/ui/main.sh
+++ b/ui/main.sh
@@ -32,8 +32,7 @@ mkdir "$DVS_REPO_RPKG" "$DVS_STORAGE_RPKG"
 
 cd "$DVS_REPO_RPKG"
 
-# this `tee` prints the R-script being executed
-tee /dev/stderr <<EOF | Rscript -
+print_eval_rscript <<EOF
 library(dvs)
 
 dvs_init("$DVS_STORAGE_RPKG")
@@ -53,12 +52,12 @@ cd "$DVS_REPO_RPKG"
 mkfiles 5 10M data/derived
 mkdatasetfiles 5 10M data/derived chickweight
 
-tee /dev/stderr <<EOF | Rscript -
+print_eval_rscript <<EOF
 library(dvs)
 
 # dvs_add("data/derived") # ERROR
 
-dvs_add("$DVS_REPO_RPKG/data/derived", glob = "*") # WORKS
+dvs_add("$DVS_REPO_RPKG/data/derived", glob = "*") |> print(width = Inf) # WORKS
 
 # conclusion: the data-frame does not contain the absolute paths even if we give it absolute paths of the files
 # data_derived_files <- c($(find "$DVS_REPO_RPKG"/data/derived -type f | sed 's/.*/"&"/' | paste -sd, -))
@@ -79,7 +78,7 @@ cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
 
-dvs_status()
+dvs_status() |> print(width = Inf)
 
 EOF
 

--- a/ui/main.sh
+++ b/ui/main.sh
@@ -97,5 +97,4 @@ EOF
 
 
 
-# This will delete everything.
-# bash ${SCRIPT_DIR}/cleanup.sh
+printf '\nCleanup: bash %s/cleanup.sh\n' "$SCRIPT_DIR"

--- a/ui/main_parallel.sh
+++ b/ui/main_parallel.sh
@@ -13,6 +13,8 @@
 set -euox pipefail
 trap 'printf "ERROR at %s:%d\n" "${BASH_SOURCE[0]}" "$LINENO" >&2' ERR
 
+echo "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 

--- a/ui/main_parallel.sh
+++ b/ui/main_parallel.sh
@@ -119,7 +119,7 @@ dvs_init("$DVS_STORAGE_R3")
 Sys.setenv(DVS_NUM_THREADS = "${THREADS}")
 
 start <- proc.time()
-dvs_add(glob = "data/derived/*")
+dvs_add(glob = "data/derived/*") |> print(width = Inf)
 r_env_elapsed <- (proc.time() - start)[["elapsed"]]
 
 Sys.unsetenv("DVS_NUM_THREADS")

--- a/ui/main_parallel.sh
+++ b/ui/main_parallel.sh
@@ -182,3 +182,5 @@ done
 if [ "$_anomalies" -gt 0 ]; then
   printf 'NOTE: %d anomaly detected — likely OS cache pressure, not a real regression\n' "$_anomalies" >&2
 fi
+
+printf '\nCleanup: bash %s/cleanup.sh\n' "$SCRIPT_DIR"

--- a/ui/main_parallel.sh
+++ b/ui/main_parallel.sh
@@ -31,14 +31,19 @@ printf '\n=== Parallel test: %d files × %s, threads=%s ===\n\n' \
 
 # ── Generate files once ─────────────────────────────────────────────
 
+# All dirs in this run share one mktemp suffix so it's obvious they belong
+# together. The R variants R0..R3 use a `_R<n>_` infix to stay distinct while
+# keeping the same trailing run-suffix.
 FIXTURES="$(mktemp -d "$SCRIPT_DIR"/dvs_fixture_XXX)"
+RUN_SUFFIX="${FIXTURES##*_}"
 cd "$FIXTURES"
 mkfiles "$N_FILES" "$FILE_SIZE" data/derived
 
 # ── CLI: DVS_NUM_THREADS env var ────────────────────────────────────
 
-DVS_REPO_CLI="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_cli_XXX)"
-DVS_STORAGE_CLI="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_cli_XXX)"
+DVS_REPO_CLI="$SCRIPT_DIR/dvs_repo_cli_$RUN_SUFFIX"
+DVS_STORAGE_CLI="$SCRIPT_DIR/dvs_storage_cli_$RUN_SUFFIX"
+mkdir "$DVS_REPO_CLI" "$DVS_STORAGE_CLI"
 cd "$DVS_REPO_CLI"
 dvs init "$DVS_STORAGE_CLI"
 cp -r "$FIXTURES/data" "$DVS_REPO_CLI/data"
@@ -49,14 +54,16 @@ CLI_ELAPSED="$( { time DVS_NUM_THREADS="$THREADS" dvs add data/derived/file_*.bi
 
 # ── R: all three methods in one process ─────────────────────────────
 
-DVS_REPO_R0="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_rpkg_XXX)"
-DVS_STORAGE_R0="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_rpkg_XXX)"
-DVS_REPO_R1="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_rpkg_XXX)"
-DVS_STORAGE_R1="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_rpkg_XXX)"
-DVS_REPO_R2="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_rpkg_XXX)"
-DVS_STORAGE_R2="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_rpkg_XXX)"
-DVS_REPO_R3="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_rpkg_XXX)"
-DVS_STORAGE_R3="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_rpkg_XXX)"
+DVS_REPO_R0="$SCRIPT_DIR/dvs_repo_rpkg_R0_$RUN_SUFFIX"
+DVS_STORAGE_R0="$SCRIPT_DIR/dvs_storage_rpkg_R0_$RUN_SUFFIX"
+DVS_REPO_R1="$SCRIPT_DIR/dvs_repo_rpkg_R1_$RUN_SUFFIX"
+DVS_STORAGE_R1="$SCRIPT_DIR/dvs_storage_rpkg_R1_$RUN_SUFFIX"
+DVS_REPO_R2="$SCRIPT_DIR/dvs_repo_rpkg_R2_$RUN_SUFFIX"
+DVS_STORAGE_R2="$SCRIPT_DIR/dvs_storage_rpkg_R2_$RUN_SUFFIX"
+DVS_REPO_R3="$SCRIPT_DIR/dvs_repo_rpkg_R3_$RUN_SUFFIX"
+DVS_STORAGE_R3="$SCRIPT_DIR/dvs_storage_rpkg_R3_$RUN_SUFFIX"
+mkdir "$DVS_REPO_R0" "$DVS_STORAGE_R0" "$DVS_REPO_R1" "$DVS_STORAGE_R1" \
+      "$DVS_REPO_R2" "$DVS_STORAGE_R2" "$DVS_REPO_R3" "$DVS_STORAGE_R3"
 
 for d in "$DVS_REPO_R0" "$DVS_REPO_R1" "$DVS_REPO_R2" "$DVS_REPO_R3"; do
   cd "$d" && cp -r "$FIXTURES/data" "$d/data"

--- a/ui/main_progress.sh
+++ b/ui/main_progress.sh
@@ -19,13 +19,19 @@ printf '\n\n========================================\n'
 printf '  SCENARIO 1: 100 x 1MB files\n'
 printf '========================================\n\n'
 
+# All scenario-1 dirs share one mktemp suffix so it's obvious they belong
+# together: dvs_fixture_AbC, dvs_repo_cli_AbC, dvs_storage_cli_AbC, etc.
 FIXTURES_1="$(mktemp -d "$SCRIPT_DIR"/dvs_fixture_XXX)"
+RUN_SUFFIX_1="${FIXTURES_1##*_}"
+DVS_REPO_CLI_1="$SCRIPT_DIR/dvs_repo_cli_$RUN_SUFFIX_1"
+DVS_STORAGE_CLI_1="$SCRIPT_DIR/dvs_storage_cli_$RUN_SUFFIX_1"
+DVS_REPO_R_1="$SCRIPT_DIR/dvs_repo_rpkg_$RUN_SUFFIX_1"
+DVS_STORAGE_R_1="$SCRIPT_DIR/dvs_storage_rpkg_$RUN_SUFFIX_1"
+mkdir "$DVS_REPO_CLI_1" "$DVS_STORAGE_CLI_1" "$DVS_REPO_R_1" "$DVS_STORAGE_R_1"
 cd "$FIXTURES_1"
 mkfiles 100 1M data/derived
 
 printf '\n--- CLI ADD: 100 x 1MB ---\n'
-DVS_REPO_CLI_1="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_cli_XXX)"
-DVS_STORAGE_CLI_1="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_cli_XXX)"
 cd "$DVS_REPO_CLI_1"
 dvs init "$DVS_STORAGE_CLI_1"
 cp -r "$FIXTURES_1/data" "$DVS_REPO_CLI_1/data"
@@ -35,8 +41,6 @@ printf '\n--- CLI GET: 100 x 1MB ---\n'
 time dvs get data/derived/*
 
 printf '\n--- RPKG ADD: 100 x 1MB ---\n'
-DVS_REPO_R_1="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_rpkg_XXX)"
-DVS_STORAGE_R_1="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_rpkg_XXX)"
 cd "$DVS_REPO_R_1"
 cp -r "$FIXTURES_1/data" "$DVS_REPO_R_1/data"
 
@@ -62,13 +66,18 @@ printf '\n\n========================================\n'
 printf '  SCENARIO 2: 1 x 500MB file\n'
 printf '========================================\n\n'
 
+# Scenario-2 dirs share their own suffix, distinct from scenario-1's.
 FIXTURES_2="$(mktemp -d "$SCRIPT_DIR"/dvs_fixture_XXX)"
+RUN_SUFFIX_2="${FIXTURES_2##*_}"
+DVS_REPO_CLI_2="$SCRIPT_DIR/dvs_repo_cli_$RUN_SUFFIX_2"
+DVS_STORAGE_CLI_2="$SCRIPT_DIR/dvs_storage_cli_$RUN_SUFFIX_2"
+DVS_REPO_R_2="$SCRIPT_DIR/dvs_repo_rpkg_$RUN_SUFFIX_2"
+DVS_STORAGE_R_2="$SCRIPT_DIR/dvs_storage_rpkg_$RUN_SUFFIX_2"
+mkdir "$DVS_REPO_CLI_2" "$DVS_STORAGE_CLI_2" "$DVS_REPO_R_2" "$DVS_STORAGE_R_2"
 cd "$FIXTURES_2"
 mkfiles 1 500M data/derived
 
 printf '\n--- CLI ADD: 1 x 500MB ---\n'
-DVS_REPO_CLI_2="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_cli_XXX)"
-DVS_STORAGE_CLI_2="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_cli_XXX)"
 cd "$DVS_REPO_CLI_2"
 dvs init "$DVS_STORAGE_CLI_2"
 cp -r "$FIXTURES_2/data" "$DVS_REPO_CLI_2/data"
@@ -78,8 +87,6 @@ printf '\n--- CLI GET: 1 x 500MB ---\n'
 time dvs get data/derived/file_1.bin
 
 printf '\n--- RPKG ADD: 1 x 500MB ---\n'
-DVS_REPO_R_2="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_rpkg_XXX)"
-DVS_STORAGE_R_2="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_rpkg_XXX)"
 cd "$DVS_REPO_R_2"
 cp -r "$FIXTURES_2/data" "$DVS_REPO_R_2/data"
 

--- a/ui/main_progress.sh
+++ b/ui/main_progress.sh
@@ -8,6 +8,8 @@
 set -euox pipefail
 trap 'printf "ERROR at %s:%d\n" "${BASH_SOURCE[0]}" "$LINENO" >&2' ERR
 
+echo "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 

--- a/ui/main_status.sh
+++ b/ui/main_status.sh
@@ -54,10 +54,12 @@ EOF
 
 # ── 1. Status: all files (default) ──
 
+echo
 echo "=== CLI: dvs status (all files) ==="
 cd "$DVS_REPO_CLI"
 dvs status
 
+echo
 echo "=== R: dvs_status() (all files) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -67,10 +69,12 @@ EOF
 
 # ── 2. Status: filter to a single file ──
 
+echo
 echo "=== CLI: dvs status data/raw/file_1.bin ==="
 cd "$DVS_REPO_CLI"
 dvs status data/raw/file_1.bin
 
+echo
 echo "=== R: dvs_status(paths = 'data/raw/file_1.bin') ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -80,10 +84,12 @@ EOF
 
 # ── 3. Status: filter to a directory (non-recursive) ──
 
+echo
 echo "=== CLI: dvs status data/ (non-recursive — direct children only) ==="
 cd "$DVS_REPO_CLI"
 dvs status data/
 
+echo
 echo "=== R: dvs_status(paths = 'data/') (non-recursive) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -93,10 +99,12 @@ EOF
 
 # ── 4. Status: filter to a directory (recursive) ──
 
+echo
 echo "=== CLI: dvs status -r data/ (recursive — all descendants) ==="
 cd "$DVS_REPO_CLI"
 dvs status -r data/
 
+echo
 echo "=== R: dvs_status(paths = 'data/', recursive = TRUE) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -106,10 +114,12 @@ EOF
 
 # ── 5. Status: filter with status flags ──
 
+echo
 echo "=== CLI: dvs status --absent (show only absent files) ==="
 cd "$DVS_REPO_CLI"
 dvs status --absent
 
+echo
 echo "=== R: dvs_status(status = 'absent') ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -122,6 +132,7 @@ EOF
 cd "$DVS_REPO_CLI"
 dvs get data/raw/file_1.bin
 
+echo
 echo "=== CLI: dvs status (mixed: 1 current, rest absent) ==="
 dvs status
 
@@ -131,6 +142,7 @@ library(dvs)
 dvs_get(paths = "data/raw/file_1.bin")
 EOF
 
+echo
 echo "=== R: dvs_status() (mixed: 1 current, rest absent) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -140,10 +152,12 @@ EOF
 
 # ── 7. Combined: path filter + status flag ──
 
+echo
 echo "=== CLI: dvs status -r data/ --current ==="
 cd "$DVS_REPO_CLI"
 dvs status -r data/ --current
 
+echo
 echo "=== R: dvs_status(paths = 'data/', recursive = TRUE, status = 'current') ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -151,10 +165,12 @@ library(dvs)
 dvs_status(paths = "data/", recursive = TRUE, status = "current")
 EOF
 
+echo
 echo "=== CLI: dvs status -r data/ --absent ==="
 cd "$DVS_REPO_CLI"
 dvs status -r data/ --absent
 
+echo
 echo "=== R: dvs_status(paths = 'data/', recursive = TRUE, status = 'absent') ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -164,6 +180,7 @@ EOF
 
 # ── 8. Status: multiple status values (several.ok) ──
 
+echo
 echo "=== R: dvs_status(status = c('current', 'absent')) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
@@ -173,10 +190,12 @@ EOF
 
 # ── 9. Multiple paths ──
 
+echo
 echo "=== CLI: dvs status data/raw/file_1.bin models/ ==="
 cd "$DVS_REPO_CLI"
 dvs status data/raw/file_1.bin models/
 
+echo
 echo "=== R: dvs_status(paths = c('data/raw/file_1.bin', 'models/')) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF

--- a/ui/main_status.sh
+++ b/ui/main_status.sh
@@ -51,83 +51,83 @@ mkfiles 2 1K models/v1
 
 print_eval_rscript <<EOF
 library(dvs)
-dvs_add(glob = "data/**/*.bin")
-dvs_add(glob = "models/**/*.bin")
+dvs_add(glob = "data/**/*.bin") |> print(width = Inf)
+dvs_add(glob = "models/**/*.bin") |> print(width = Inf)
 EOF
 
 # ── 1. Status: all files (default) ──
 
-echo
-echo "=== CLI: dvs status (all files) ==="
+say
+say "=== CLI: dvs status (all files) ==="
 cd "$DVS_REPO_CLI"
 dvs status
 
-echo
-echo "=== R: dvs_status() (all files) ==="
+say
+say "=== R: dvs_status() (all files) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status()
+dvs_status() |> print(width = Inf)
 EOF
 
 # ── 2. Status: filter to a single file ──
 
-echo
-echo "=== CLI: dvs status data/raw/file_1.bin ==="
+say
+say "=== CLI: dvs status data/raw/file_1.bin ==="
 cd "$DVS_REPO_CLI"
 dvs status data/raw/file_1.bin
 
-echo
-echo "=== R: dvs_status(paths = 'data/raw/file_1.bin') ==="
+say
+say "=== R: dvs_status(paths = 'data/raw/file_1.bin') ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status(paths = "data/raw/file_1.bin")
+dvs_status(paths = "data/raw/file_1.bin") |> print(width = Inf)
 EOF
 
 # ── 3. Status: filter to a directory (non-recursive) ──
 
-echo
-echo "=== CLI: dvs status data/ (non-recursive — direct children only) ==="
+say
+say "=== CLI: dvs status data/ (non-recursive — direct children only) ==="
 cd "$DVS_REPO_CLI"
 dvs status data/
 
-echo
-echo "=== R: dvs_status(paths = 'data/') (non-recursive) ==="
+say
+say "=== R: dvs_status(paths = 'data/') (non-recursive) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status(paths = "data/")
+dvs_status(paths = "data/") |> print(width = Inf)
 EOF
 
 # ── 4. Status: filter to a directory (recursive) ──
 
-echo
-echo "=== CLI: dvs status -r data/ (recursive — all descendants) ==="
+say
+say "=== CLI: dvs status -r data/ (recursive — all descendants) ==="
 cd "$DVS_REPO_CLI"
 dvs status -r data/
 
-echo
-echo "=== R: dvs_status(paths = 'data/', recursive = TRUE) ==="
+say
+say "=== R: dvs_status(paths = 'data/', recursive = TRUE) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status(paths = "data/", recursive = TRUE)
+dvs_status(paths = "data/", recursive = TRUE) |> print(width = Inf)
 EOF
 
 # ── 5. Status: filter with status flags ──
 
-echo
-echo "=== CLI: dvs status --absent (show only absent files) ==="
+say
+say "=== CLI: dvs status --absent (show only absent files) ==="
 cd "$DVS_REPO_CLI"
 dvs status --absent
 
-echo
-echo "=== R: dvs_status(status = 'absent') ==="
+say
+say "=== R: dvs_status(status = 'absent') ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status(status = "absent")
+dvs_status(status = "absent") |> print(width = Inf)
 EOF
 
 # ── 6. Retrieve some files, then show mixed status ──
@@ -135,75 +135,75 @@ EOF
 cd "$DVS_REPO_CLI"
 dvs get data/raw/file_1.bin
 
-echo
-echo "=== CLI: dvs status (mixed: 1 current, rest absent) ==="
+say
+say "=== CLI: dvs status (mixed: 1 current, rest absent) ==="
 dvs status
 
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_get(paths = "data/raw/file_1.bin")
+dvs_get(paths = "data/raw/file_1.bin") |> print(width = Inf)
 EOF
 
-echo
-echo "=== R: dvs_status() (mixed: 1 current, rest absent) ==="
+say
+say "=== R: dvs_status() (mixed: 1 current, rest absent) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status()
+dvs_status() |> print(width = Inf)
 EOF
 
 # ── 7. Combined: path filter + status flag ──
 
-echo
-echo "=== CLI: dvs status -r data/ --current ==="
+say
+say "=== CLI: dvs status -r data/ --current ==="
 cd "$DVS_REPO_CLI"
 dvs status -r data/ --current
 
-echo
-echo "=== R: dvs_status(paths = 'data/', recursive = TRUE, status = 'current') ==="
+say
+say "=== R: dvs_status(paths = 'data/', recursive = TRUE, status = 'current') ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status(paths = "data/", recursive = TRUE, status = "current")
+dvs_status(paths = "data/", recursive = TRUE, status = "current") |> print(width = Inf)
 EOF
 
-echo
-echo "=== CLI: dvs status -r data/ --absent ==="
+say
+say "=== CLI: dvs status -r data/ --absent ==="
 cd "$DVS_REPO_CLI"
 dvs status -r data/ --absent
 
-echo
-echo "=== R: dvs_status(paths = 'data/', recursive = TRUE, status = 'absent') ==="
+say
+say "=== R: dvs_status(paths = 'data/', recursive = TRUE, status = 'absent') ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status(paths = "data/", recursive = TRUE, status = "absent")
+dvs_status(paths = "data/", recursive = TRUE, status = "absent") |> print(width = Inf)
 EOF
 
 # ── 8. Status: multiple status values (several.ok) ──
 
-echo
-echo "=== R: dvs_status(status = c('current', 'absent')) ==="
+say
+say "=== R: dvs_status(status = c('current', 'absent')) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status(status = c("current", "absent"))
+dvs_status(status = c("current", "absent")) |> print(width = Inf)
 EOF
 
 # ── 9. Multiple paths ──
 
-echo
-echo "=== CLI: dvs status data/raw/file_1.bin models/ ==="
+say
+say "=== CLI: dvs status data/raw/file_1.bin models/ ==="
 cd "$DVS_REPO_CLI"
 dvs status data/raw/file_1.bin models/
 
-echo
-echo "=== R: dvs_status(paths = c('data/raw/file_1.bin', 'models/')) ==="
+say
+say "=== R: dvs_status(paths = c('data/raw/file_1.bin', 'models/')) ==="
 cd "$DVS_REPO_RPKG"
 print_eval_rscript <<EOF
 library(dvs)
-dvs_status(paths = c("data/raw/file_1.bin", "models/"))
+dvs_status(paths = c("data/raw/file_1.bin", "models/")) |> print(width = Inf)
 EOF
 
 printf '\nCleanup: bash %s/cleanup.sh\n' "$SCRIPT_DIR"

--- a/ui/main_status.sh
+++ b/ui/main_status.sh
@@ -203,3 +203,5 @@ print_eval_rscript <<EOF
 library(dvs)
 dvs_status(paths = c("data/raw/file_1.bin", "models/"))
 EOF
+
+printf '\nCleanup: bash %s/cleanup.sh\n' "$SCRIPT_DIR"

--- a/ui/main_status.sh
+++ b/ui/main_status.sh
@@ -6,6 +6,8 @@
 set -euox pipefail
 trap 'printf "ERROR at %s:%d\n" "${BASH_SOURCE[0]}" "$LINENO" >&2' ERR
 
+echo "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 

--- a/ui/main_status.sh
+++ b/ui/main_status.sh
@@ -15,10 +15,11 @@ source "${SCRIPT_DIR}/helpers.sh"
 # ── Setup: two repos (CLI + R), nested directory structure ──
 
 DVS_REPO_CLI="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_cli_XXX)"
-DVS_STORAGE_CLI="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_cli_XXX)"
-
-DVS_REPO_RPKG="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_rpkg_XXX)"
-DVS_STORAGE_RPKG="$(mktemp -d "$SCRIPT_DIR"/dvs_storage_rpkg_XXX)"
+RUN_SUFFIX="${DVS_REPO_CLI##*_}"
+DVS_STORAGE_CLI="$SCRIPT_DIR/dvs_storage_cli_$RUN_SUFFIX"
+DVS_REPO_RPKG="$SCRIPT_DIR/dvs_repo_rpkg_$RUN_SUFFIX"
+DVS_STORAGE_RPKG="$SCRIPT_DIR/dvs_storage_rpkg_$RUN_SUFFIX"
+mkdir "$DVS_STORAGE_CLI" "$DVS_REPO_RPKG" "$DVS_STORAGE_RPKG"
 
 # ── Init ──
 


### PR DESCRIPTION
## Summary

Cross-cutting UI test improvements pulled out of #154 so that PR can stay focused on the get-recursive feature. Five commits:

1. **Blank-line separators before `=== ===` headers** across `main_status.sh`, `main_progress.sh`, `main_parallel.sh`, `main.sh`.
2. **Cleanup-hint printf at the end** of every `main*.sh`.
3. **Shared mktemp suffix** across related dirs (cli/rpkg repo + storage) in each `main*.sh`.
4. **`just install-all` reminder** echo at the top of every `main*.sh`.
5. **`PS4='> '`, `say()`, `print(width = Inf)`, and `just ui-publish` recipes**:
   - `ui/helpers.sh` adds `mkrandfile` (hides `head -c` from set -x), `PS4='> '` as the xtrace prefix, and `say` for echoes that shouldn't leave a `+ echo ...` trace line.
   - `ui/main_status.sh` swaps bare `echo` / `echo "=== ... ==="` for `say`, and pipes tibble-returning R calls to `|> print(width = Inf)` for full-width log output.
   - `ui/main.sh`, `ui/main_parallel.sh` get the same `print(width = Inf)` change.
   - `justfile` adds `ui-run`, `ui-render`, `ui-publish-only`, and `ui-publish` — runs each `ui/main*.sh`, wraps the log into `ui/output/ui-<NAME>.html`, publishes to alx project from `.alx/config.yaml`. Names driven by `ui_names`.

Notes:
- `main_recursive.sh` (and its `--recursive` demo content) is intentionally NOT touched here — it ships with #154.
- `just ui-publish` depends on `.alx/config.yaml`, which lands in #165.

## Test plan

- [x] `bash -n` clean on all touched `ui/main*.sh`
- [x] `just --list` enumerates the new `ui-*` recipes
- [x] `just ui-publish` was used to regenerate and publish all five HTML artifacts to alx during this session
- [ ] R tibbles render with full width in `ui/output/*.html` — visual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)