### PR TITLE
chore(ui): replace bare echo with say() in main.sh / main_parallel.sh / main_progress.sh

### DIFF
--- a/ui/main.sh
+++ b/ui/main.sh
@@ -5,13 +5,13 @@ set -euox pipefail
 # prints the line in script that errors
 trap 'printf "ERROR at %s:%d\n" "${BASH_SOURCE[0]}" "$LINENO" >&2' ERR
 
-echo "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # shellcheck source=ui/helpers.sh
 source "${SCRIPT_DIR}/helpers.sh"
+
+say "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
 
 DVS_REPO_CLI="$(mktemp -d "$SCRIPT_DIR"/dvs_repo_cli_XXX)"
 RUN_SUFFIX="${DVS_REPO_CLI##*_}"

--- a/ui/main_parallel.sh
+++ b/ui/main_parallel.sh
@@ -13,13 +13,13 @@
 set -euox pipefail
 trap 'printf "ERROR at %s:%d\n" "${BASH_SOURCE[0]}" "$LINENO" >&2' ERR
 
-echo "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # shellcheck source=ui/helpers.sh
 source "${SCRIPT_DIR}/helpers.sh"
+
+say "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
 
 N_FILES="${1:-20}"
 FILE_SIZE="${2:-50M}"

--- a/ui/main_progress.sh
+++ b/ui/main_progress.sh
@@ -8,12 +8,12 @@
 set -euox pipefail
 trap 'printf "ERROR at %s:%d\n" "${BASH_SOURCE[0]}" "$LINENO" >&2' ERR
 
-echo "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 source "${SCRIPT_DIR}/helpers.sh"
+
+say "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH and the installed dvs R package both reflect the current branch."
 
 # ── Scenario 1: 100 x 1MB files ────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Replaces each column-0 `echo "NOTE: ..."` header call in `ui/main.sh`, `ui/main_parallel.sh`, and `ui/main_progress.sh` with `say()` from `helpers.sh`.
- Moves each `say` call to after `source "${SCRIPT_DIR}/helpers.sh"` so the helper is in scope when it runs (the original `echo` calls ran before the source, which worked since `echo` is a shell builtin; `say` requires the source to be loaded first).
- 1 site converted per file (3 total). Indented `echo`s, `printf`s, and `|| echo` fallbacks were left untouched.

## Test plan

- [ ] `bash -n ui/main.sh && bash -n ui/main_parallel.sh && bash -n ui/main_progress.sh` — all syntax clean
- [ ] `grep -cE '^echo$|^echo "' ui/main.sh ui/main_parallel.sh ui/main_progress.sh` — all report 0
- [ ] `grep -cE '^say$|^say "' ui/main.sh ui/main_parallel.sh ui/main_progress.sh` — all report 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)