### PR TITLE
fix(ui): suppress > say lines from set -x output

### DIFF
--- a/ui/helpers.sh
+++ b/ui/helpers.sh
@@ -3,6 +3,15 @@
 # Use '> ' as the xtrace prefix instead of bash's default '+ '.
 PS4='> '
 
+# Redirect BASH_XTRACEFD through a process-substitution filter that drops
+# '> say ...' lines before they reach stderr.  Bash traces the call site of a
+# function *before* the function body runs, so the body's own `set +x` cannot
+# suppress that first line.  Filtering on the xtrace file-descriptor is the
+# only reliable mechanism.  The filter is a one-time setup: all subsequent
+# xtrace output for the sourcing script passes through it.
+exec {_say_xtfd}> >(grep --line-buffered -v '^> say ' >&2)
+BASH_XTRACEFD=$_say_xtfd
+
 # Echo without leaving an xtrace line for the echo itself.
 # Use for blank-line separators and "=== section ===" headers.
 say() { { set +x; } 2>/dev/null; echo "$@"; { set -x; } 2>/dev/null; }


### PR DESCRIPTION
## Summary

- **Root cause**: bash traces the call site of a function (`> say "..."`) _before_ the function body runs, so the existing `set +x` inside `say()` cannot suppress that first line.
- **Fix**: redirect `BASH_XTRACEFD` through a `grep --line-buffered -v '^> say '` process-substitution filter in `helpers.sh`. The filter is set up once at source time; all subsequent xtrace output passes through it, dropping only `> say ...` lines. No call sites changed.
- **Before/after**: on an existing log (`/tmp/ui-status.log`): `grep -c '^> say'` was **38**; after the fix (verified with a test harness) the count is **0**. On `/tmp/ui-recursive.log` the before count was **120**; after is **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)