### PR TITLE
chore(ui): add tree views to main.sh + main_status.sh fixtures

### DIFF
--- a/ui/main.sh
+++ b/ui/main.sh
@@ -42,15 +42,18 @@ EOF
 
 cd "$DVS_REPO_CLI"
 mkfiles 5 10M data/derived
-dvs add data/derived/file_*.bin
-
 mkdatasetfiles 5 10M data/derived chickweight
+say "--- tree data (5 .bin + 5 chickweight .csv) ---"
+tree --noreport data
+dvs add data/derived/file_*.bin
 dvs add data/derived/file_chickweight_*.csv
 
 cd "$DVS_REPO_RPKG"
 
 mkfiles 5 10M data/derived
 mkdatasetfiles 5 10M data/derived chickweight
+say "--- tree data (5 .bin + 5 chickweight .csv) ---"
+tree --noreport data
 
 print_eval_rscript <<EOF
 library(dvs)

--- a/ui/main_status.sh
+++ b/ui/main_status.sh
@@ -40,6 +40,8 @@ cd "$DVS_REPO_CLI"
 mkfiles 3 1K data/raw
 mkfiles 2 1K data/derived
 mkfiles 2 1K models/v1
+say "--- tree (3 raw + 2 derived + 2 models, 7 files total) ---"
+tree --noreport
 
 dvs add --glob "data/**/*.bin"
 dvs add --glob "models/**/*.bin"
@@ -48,6 +50,8 @@ cd "$DVS_REPO_RPKG"
 mkfiles 3 1K data/raw
 mkfiles 2 1K data/derived
 mkfiles 2 1K models/v1
+say "--- tree (3 raw + 2 derived + 2 models, 7 files total) ---"
+tree --noreport
 
 print_eval_rscript <<EOF
 library(dvs)


### PR DESCRIPTION
## Summary

- Adds `tree --noreport data` in `ui/main.sh` after each repo's `mkfiles + mkdatasetfiles` block (CLI repo and R repo), showing the 5 `.bin` + 5 chickweight `.csv` fixture layout before the `dvs add` step.
- Adds `tree --noreport` in `ui/main_status.sh` after each repo's three-`mkfiles` triplet (CLI repo and R repo), showing the nested `data/raw/`, `data/derived/`, `models/v1/` layout before the `dvs add` step.
- `main_parallel.sh` and `main_progress.sh` intentionally skipped — their single flat directory of N identical files produces no informative tree output; the existing xtrace line already conveys what was created.