### PR TITLE
feat(rpkg): add detect-features.R and document DVS_FEATURES → CARGO_FEATURES rename

### DIFF
--- a/dvs-rpkg/CLAUDE.md
+++ b/dvs-rpkg/CLAUDE.md
@@ -149,6 +149,9 @@ Results are returned as DataFrames using miniextendr's `AsSerializeRow` trait. E
 | `CARGO_PROFILE` | `release` (default) or `debug` |
 | `CARGO_FEATURES` | Comma-separated cargo features (e.g., `nonapi`) |
 | `RUST_TOOLCHAIN` | e.g., `+stable`, `+nightly` |
+| `DVS_AUTO_FEATURES` | Escape hatch for `tools/detect-features.R`; inject features without setting `CARGO_FEATURES` (which would skip the script entirely) |
+
+**Migration note (post #171):** the package-level cargo-features env var renamed from `DVS_FEATURES` to `CARGO_FEATURES`. Existing scripts setting `DVS_FEATURES` are now no-ops — update them or set both during transition.
 
 ## Adding New Rust Functions
 

--- a/dvs-rpkg/tools/detect-features.R
+++ b/dvs-rpkg/tools/detect-features.R
@@ -1,0 +1,36 @@
+# Feature detection for dvs-rpkg
+# Called by ./configure to auto-detect which Cargo features to enable.
+# Output: comma-separated list of Cargo features to enable (printed via cat()).
+#
+# The upstream miniextendr detect-features.R template is not applicable here:
+# it lists miniextendr framework features (rayon, ndarray, vctrs, …) that
+# dvs-rpkg does not expose. dvs-rpkg has exactly two optional features:
+#
+#   nonapi      — enables non-standard R API calls in miniextendr-api.
+#                 Causes R CMD check WARNINGS. Never auto-enable.
+#   connections — enables R's connection framework in miniextendr-api.
+#                 The R connections API is explicitly marked unstable upstream.
+#                 Never auto-enable.
+#
+# Neither feature is used in dvs-rpkg's own lib.rs; they only affect
+# miniextendr-api internals. The safe default is no extra features.
+#
+# To opt in, set CARGO_FEATURES before running configure:
+#   CARGO_FEATURES=connections bash ./configure
+# (configure guards on `test -z "${CARGO_FEATURES+x}"` so an env var always
+# wins over this script — see configure.ac lines ~80-92.)
+#
+# Alternatively, set DVS_AUTO_FEATURES here as an escape hatch during
+# development without touching the configure invocation:
+#   DVS_AUTO_FEATURES=connections bash ./configure
+
+features <- character()
+
+# Escape hatch: DVS_AUTO_FEATURES lets developers inject features without
+# having to set CARGO_FEATURES (which would prevent this script from running).
+auto <- Sys.getenv("DVS_AUTO_FEATURES", unset = "")
+if (nzchar(auto)) {
+  features <- c(features, strsplit(auto, ",")[[1]])
+}
+
+cat(paste(features, collapse = ","))


### PR DESCRIPTION
## Summary

- Adds `dvs-rpkg/tools/detect-features.R` so configure.ac's auto-detection block finds the script and stops emitting the "not found — building with no extra cargo features" warning introduced by #171.
- The script emits an empty feature list by default: neither `nonapi` (causes `R CMD check` warnings) nor `connections` (uses an explicitly unstable R API) should be auto-enabled for dvs-rpkg. Operators can still pass `CARGO_FEATURES=...` to configure, or use the `DVS_AUTO_FEATURES` escape hatch documented in the script header.
- Adds a migration note to `dvs-rpkg/CLAUDE.md`'s Environment Variables section documenting the `DVS_FEATURES` → `CARGO_FEATURES` rename that landed silently in #171.

## Option chosen: B (dvs-specific minimal script, not the upstream template)

The upstream `detect-features.R` in `miniextendr/rpkg/tools/` lists ~30 miniextendr framework features (rayon, ndarray, vctrs, …). dvs-rpkg has exactly two optional features (`nonapi`, `connections`) and neither should be auto-enabled. Blindly copying the upstream script would have been wrong.

## Validation

```bash
# Default: no extra features, no warning
cd dvs-rpkg && bash ./configure 2>&1 | grep -E 'CARGO_FEATURES|features|not found'
# → configure: CARGO_PROFILE = release   (CARGO_FEATURES absent = empty, no warning)

# Env var wins over script (configure guard: test -z "${CARGO_FEATURES+x}")
CARGO_FEATURES=nonapi bash ./configure 2>&1 | grep CARGO_FEATURES
# → configure: CARGO_FEATURES  = nonapi

# Script standalone
Rscript dvs-rpkg/tools/detect-features.R   # → (empty, exit 0)
DVS_AUTO_FEATURES=connections Rscript dvs-rpkg/tools/detect-features.R  # → connections
```

Fixes the configure-time no-op and docs gap left by #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)