### PR TITLE
fix(rpkg): correctness fixes and FFI smoke for all four install tests

### DIFF
--- a/dvs-rpkg/tests/install-devtools
+++ b/dvs-rpkg/tests/install-devtools
@@ -38,7 +38,14 @@ devtools::install_github(
 )
 RSCRIPT
 
-echo "=== verify dvs is loadable ==="
-Rscript -e ".libPaths(c('$LIB', .libPaths())); library(dvs); cat('dvs loaded successfully\n')"
+echo "=== FFI smoke: dvs_init ==="
+SMOKE_ROOT="$(mktemp -d)"
+SMOKE_STORE="$(mktemp -d)"
+Rscript -e "
+  .libPaths(c('$LIB', .libPaths()))
+  dvs::dvs_init('$SMOKE_STORE', root_dir = '$SMOKE_ROOT')
+  cat('dvs FFI smoke OK\n')
+"
+rm -rf "$SMOKE_ROOT" "$SMOKE_STORE"
 
 echo "PASS"

--- a/dvs-rpkg/tests/install-github
+++ b/dvs-rpkg/tests/install-github
@@ -24,7 +24,7 @@ mkdir -p "$LIB"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 echo "=== remotes::install_github $REMOTE_REPO@$SHA, subdir=dvs-rpkg ==="
-R_LIBS_USER="$LIB" Rscript --vanilla - <<RSCRIPT
+Rscript --vanilla - <<RSCRIPT
 .libPaths(c("$LIB", .libPaths()))
 if (!requireNamespace("remotes", quietly = TRUE)) {
   install.packages("remotes", lib = "$LIB", repos = "https://cloud.r-project.org")
@@ -38,7 +38,14 @@ remotes::install_github(
 )
 RSCRIPT
 
-echo "=== verify dvs is loadable ==="
-Rscript -e ".libPaths(c('$LIB', .libPaths())); library(dvs); cat('dvs loaded successfully\n')"
+echo "=== FFI smoke: dvs_init ==="
+SMOKE_ROOT="$(mktemp -d)"
+SMOKE_STORE="$(mktemp -d)"
+Rscript -e "
+  .libPaths(c('$LIB', .libPaths()))
+  dvs::dvs_init('$SMOKE_STORE', root_dir = '$SMOKE_ROOT')
+  cat('dvs FFI smoke OK\n')
+"
+rm -rf "$SMOKE_ROOT" "$SMOKE_STORE"
 
 echo "PASS"

--- a/dvs-rpkg/tests/install-rv-github
+++ b/dvs-rpkg/tests/install-rv-github
@@ -28,7 +28,23 @@ rv init
 echo "=== rv add dvs --git $REMOTE_URL --commit $SHA --directory dvs-rpkg ==="
 rv add dvs --git "$REMOTE_URL" --commit "$SHA" --directory dvs-rpkg
 
-echo "=== verify dvs is loadable ==="
-Rscript -e 'library(dvs); cat("dvs loaded successfully\n")'
+echo "=== resolve rv library path ==="
+# rv lays out packages at rv/library/<R-version>/<arch>/ (no trailing /library)
+RV_LIB="$(echo "$TMPDIR"/rv/library/*/*)"
+if [ ! -d "$RV_LIB" ]; then
+  echo "ERROR: rv library directory not found at expected glob $TMPDIR/rv/library/*/*" >&2
+  exit 1
+fi
+echo "rv lib: $RV_LIB"
+
+echo "=== FFI smoke: dvs_init ==="
+SMOKE_ROOT="$(mktemp -d)"
+SMOKE_STORE="$(mktemp -d)"
+Rscript -e "
+  .libPaths(c('$RV_LIB', .libPaths()))
+  dvs::dvs_init('$SMOKE_STORE', root_dir = '$SMOKE_ROOT')
+  cat('dvs FFI smoke OK\n')
+"
+rm -rf "$SMOKE_ROOT" "$SMOKE_STORE"
 
 echo "PASS"

--- a/dvs-rpkg/tests/install-tarball
+++ b/dvs-rpkg/tests/install-tarball
@@ -9,7 +9,13 @@ ROOT_DIR="$(cd "${RPKG_DIR}/.." && pwd)"
 TMPDIR="$(mktemp -d)"
 LIB="$TMPDIR/Rlib"
 mkdir -p "$LIB"
-trap 'rm -rf "$TMPDIR"' EXIT
+
+RESTORE_PATHS=("dvs-rpkg/src/rust/Cargo.toml" "dvs-rpkg/src/rust/Cargo.lock")
+cleanup() {
+  rm -rf "$TMPDIR"
+  ( cd "$ROOT_DIR" && git checkout HEAD -- "${RESTORE_PATHS[@]}" 2>/dev/null || true )
+}
+trap cleanup EXIT
 
 echo "=== just vendor (populate inst/vendor.tar.xz) ==="
 ( cd "$ROOT_DIR" && just vendor )
@@ -26,7 +32,14 @@ CARGO_HOME="$TMPDIR/cargo-home" \
 CARGO_NET_OFFLINE=1 \
   R CMD INSTALL --no-test-load --library="$LIB" "$TARBALL"
 
-echo "=== verify dvs is loadable ==="
-Rscript -e ".libPaths(c('$LIB', .libPaths())); library(dvs); cat('dvs loaded successfully\n')"
+echo "=== FFI smoke: dvs_init ==="
+SMOKE_ROOT="$(mktemp -d)"
+SMOKE_STORE="$(mktemp -d)"
+Rscript -e "
+  .libPaths(c('$LIB', .libPaths()))
+  dvs::dvs_init('$SMOKE_STORE', root_dir = '$SMOKE_ROOT')
+  cat('dvs FFI smoke OK\n')
+"
+rm -rf "$SMOKE_ROOT" "$SMOKE_STORE"
 
 echo "PASS"


### PR DESCRIPTION
Follows up on #171 (merged) — four real correctness issues surfaced in review after the tests ran green.

## Changes

- **install-tarball — working tree pollution**: `just vendor` freezes `dvs-rpkg/src/rust/Cargo.toml` and `Cargo.lock` to vendor paths. Added an EXIT trap that runs `git checkout HEAD -- <paths>` on exit so those mutations are never left in the tree.

- **install-github — dead env var**: `R_LIBS_USER="$LIB"` was set on the heredoc Rscript invocation but the heredoc immediately calls `.libPaths(c("$LIB", ...))`, making the env var redundant. Dropped it for consistency with install-devtools.

- **install-rv-github — phantom pass risk**: `library(dvs)` was called without prepending the rv-managed lib path to `.libPaths()`, so R could load a previously installed system dvs instead of the freshly built one. Now resolves the rv lib path via glob (`rv/library/*/*`) and prepends it explicitly.

- **All four — no FFI coverage**: `library(dvs)` only verifies namespace load, not that any `.Call` works. Replaced with `dvs::dvs_init(storage, root_dir = root)` using two independent `mktemp -d` dirs (storage outside root, both unique per run) to exercise the full Rust-R shim.

## Test plan

- [ ] `bash dvs-rpkg/tests/install-tarball` passes; `git status -- dvs-rpkg/src/rust/` shows nothing modified after it exits
- [ ] `bash dvs-rpkg/tests/install-github` passes with "dvs FFI smoke OK"
- [ ] `bash dvs-rpkg/tests/install-devtools` passes with "dvs FFI smoke OK"
- [ ] `bash dvs-rpkg/tests/install-rv-github` passes with "dvs FFI smoke OK"

All four verified locally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)