### PR TITLE
ci(release): smoke-test built binary + clarify tag guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ jobs:
           fi
           cargo build --all --features=cli --release --target ${{ matrix.target }}
 
+      - name: Smoke-test built binary
+        if: matrix.target == 'x86_64-unknown-linux-gnu'  # only native target
+        run: ./target/${{ matrix.target }}/release/dvs --version
+
       - name: Prepare binary for upload
         run: |
           mkdir -p artifacts
@@ -69,6 +73,7 @@ jobs:
   Create-Release:
     needs: [Build-Binaries]
     runs-on: ubuntu-latest
+    # Guard for workflow_dispatch (manual) runs — only release on tag pushes, never on dispatch.
     if: ${{ github.ref_type == 'tag' }}
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Add a `dvs --version` smoke-test step after `cargo build`, gated to `x86_64-unknown-linux-gnu` (the native target; aarch64 cross-compile runner can't execute the binary)
- Add a comment on `Create-Release`'s `if: github.ref_type == 'tag'` explaining it guards `workflow_dispatch` manual runs (without it the condition looks redundant with the `tags: ["v*.*.*"]` push trigger)

## Changes

- `.github/workflows/release.yml`: 5 lines added

## Test plan

- [ ] CI passes on this PR (Build-Binaries job; smoke-test step runs for x86_64 and prints the version string)
- [ ] No functional change to the release flow