### PR TITLE
feat(threads): observable priority chain + verifier script

### DIFF
--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -25,6 +25,24 @@ pub(crate) fn get_num_threads() -> Option<usize> {
     }
 }
 
+/// Which tier of the priority chain produced the thread count.
+#[derive(Debug, Clone, Copy)]
+enum ThreadSource {
+    Override,
+    Environment,
+    Default,
+}
+
+impl std::fmt::Display for ThreadSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Override => "override",
+            Self::Environment => "environment",
+            Self::Default => "default",
+        })
+    }
+}
+
 const KB: u64 = 1_024;
 const MB: u64 = 1_024 * 1_024;
 const GB: u64 = 1_024 * 1_024 * 1_024;
@@ -100,25 +118,27 @@ pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
         .unwrap_or(1)
         .max(1);
 
-    let num_threads;
-    let source;
-    if let Some(n) = get_num_threads() {
-        num_threads = n.min(ENV_MAX_THREADS).min(work_limit);
-        source = "override";
-    } else if let Some(n) = std::env::var("DVS_NUM_THREADS")
+    let override_threads = get_num_threads();
+    let env_threads = std::env::var("DVS_NUM_THREADS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-    {
-        num_threads = n.min(ENV_MAX_THREADS).min(work_limit);
-        source = "environment";
-    } else {
-        num_threads = available_cpus
+        .filter(|&n| n > 0);
+
+    let num_threads = match (override_threads, env_threads) {
+        (Some(n), _) | (None, Some(n)) => n.min(ENV_MAX_THREADS).min(work_limit),
+        (None, None) => available_cpus
             .saturating_mul(DEFAULT_THREADS_PER_CPU)
             .min(DEFAULT_MAX_THREADS)
-            .min(work_limit);
-        source = "default";
-    }
+            .min(work_limit),
+    };
+
+    let source = if override_threads.is_some() {
+        ThreadSource::Override
+    } else if env_threads.is_some() {
+        ThreadSource::Environment
+    } else {
+        ThreadSource::Default
+    };
 
     log::debug!(
         "thread pool: {num_threads} threads (source: {source}, work_items={work_items})",

--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -6,13 +6,13 @@ const DEFAULT_THREADS_PER_CPU: usize = 4;
 /// Maximum thread count threshold when `DVS_NUM_THREADS` is unset
 const DEFAULT_MAX_THREADS: usize = 16;
 /// Maximum thread count threshold if `DVS_NUM_THREADS` is set
-const ENV_MAX_THREADS: usize = 32;
+const ENVIRONMENT_MAX_THREADS: usize = 32;
 
-/// Global thread count override. 0 = unset (use env var or default).
+/// Global thread count override. 0 = unset (use environment variable or default).
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(0);
 
 /// Set the number of threads for DVS parallel operations.
-/// Pass 0 to clear (revert to env var / automatic detection).
+/// Pass 0 to clear (revert to environment variable / automatic detection).
 pub fn set_num_threads(n: usize) {
     NUM_THREADS.store(n, Ordering::Relaxed);
 }
@@ -102,9 +102,9 @@ pub fn parse_size(size: &str) -> Result<u64> {
 /// Creates a rayon thread pool with a thread count resolved from a 3-tier
 /// priority chain, each clamped to `work_items`:
 ///
-/// 1. **Override** — `set_num_threads(n)` (capped at `ENV_MAX_THREADS`)
-/// 2. **Env** — `DVS_NUM_THREADS` env var, must parse to `usize > 0`
-///    (capped at `ENV_MAX_THREADS`)
+/// 1. **Override** — `set_num_threads(n)` (capped at `ENVIRONMENT_MAX_THREADS`)
+/// 2. **Environment** — `DVS_NUM_THREADS` environment variable, must parse to
+///    `usize > 0` (capped at `ENVIRONMENT_MAX_THREADS`)
 /// 3. **Default** — `available_cpus * DEFAULT_THREADS_PER_CPU`
 ///    (capped at `DEFAULT_MAX_THREADS`)
 pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
@@ -119,13 +119,13 @@ pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
         .max(1);
 
     let override_threads = get_num_threads();
-    let env_threads = std::env::var("DVS_NUM_THREADS")
+    let environment_threads = std::env::var("DVS_NUM_THREADS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|&n| n > 0);
 
-    let num_threads = match (override_threads, env_threads) {
-        (Some(n), _) | (None, Some(n)) => n.min(ENV_MAX_THREADS).min(work_limit),
+    let num_threads = match (override_threads, environment_threads) {
+        (Some(n), _) | (None, Some(n)) => n.min(ENVIRONMENT_MAX_THREADS).min(work_limit),
         (None, None) => available_cpus
             .saturating_mul(DEFAULT_THREADS_PER_CPU)
             .min(DEFAULT_MAX_THREADS)
@@ -134,7 +134,7 @@ pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
 
     let source = if override_threads.is_some() {
         ThreadSource::Override
-    } else if env_threads.is_some() {
+    } else if environment_threads.is_some() {
         ThreadSource::Environment
     } else {
         ThreadSource::Default

--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -104,17 +104,25 @@ pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|&n| n > 0);
     // Priority: set_num_threads() > DVS_NUM_THREADS env var > default
-    let num_threads = {
+    let (num_threads, source) = {
         let work_limit = work_items.max(1);
 
-        let configured = match get_num_threads().or(env_threads) {
-            Some(n) => n.min(ENV_MAX_THREADS),
-            None => available
-                .saturating_mul(DEFAULT_THREADS_PER_CPU)
-                .min(DEFAULT_MAX_THREADS),
+        let (configured, source) = match (get_num_threads(), env_threads) {
+            (Some(n), _) => (n.min(ENV_MAX_THREADS), "override"),
+            (None, Some(n)) => (n.min(ENV_MAX_THREADS), "env"),
+            (None, None) => (
+                available
+                    .saturating_mul(DEFAULT_THREADS_PER_CPU)
+                    .min(DEFAULT_MAX_THREADS),
+                "default",
+            ),
         };
-        configured.min(work_limit)
+        (configured.min(work_limit), source)
     };
+
+    log::debug!(
+        "thread pool: {num_threads} threads (source: {source}, work_items={work_items})"
+    );
 
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)

--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -81,47 +81,43 @@ pub fn parse_size(size: &str) -> Result<u64> {
     Ok((num * multiplier as f64) as u64)
 }
 
-/// Creates a rayon thread pool.
+/// Creates a rayon thread pool with a thread count resolved from a 3-tier
+/// priority chain, each clamped to `work_items`:
 ///
-/// Thread count priority (highest to lowest):
-/// 1. Global override via [`set_num_threads`] (capped at 32)
-/// 2. `DVS_NUM_THREADS` environment variable (capped at 32)
-/// 3. Default: `available_cpus * 4` (capped at 16)
-///
-/// The result is always clamped to the number of work items.
+/// 1. **Override** — `set_num_threads(n)` (capped at `ENV_MAX_THREADS`)
+/// 2. **Env** — `DVS_NUM_THREADS` env var, must parse to `usize > 0`
+///    (capped at `ENV_MAX_THREADS`)
+/// 3. **Default** — `available_cpus * DEFAULT_THREADS_PER_CPU`
+///    (capped at `DEFAULT_MAX_THREADS`)
 pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
     debug_assert_ne!(
         work_items, 0,
         "the thread pool should not be instantiated when there are no work items to process"
     );
-    // a proxy for available logical cpu cores
-    let available = std::thread::available_parallelism()
+    let work_limit = work_items.max(1);
+    let available_cpus = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1)
         .max(1);
-    let env_threads = std::env::var("DVS_NUM_THREADS")
+
+    let (num_threads, source) = if let Some(n) = get_num_threads() {
+        (n.min(ENV_MAX_THREADS).min(work_limit), "override")
+    } else if let Some(n) = std::env::var("DVS_NUM_THREADS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0);
-    // Priority: set_num_threads() > DVS_NUM_THREADS env var > default
-    let (num_threads, source) = {
-        let work_limit = work_items.max(1);
-
-        let (configured, source) = match (get_num_threads(), env_threads) {
-            (Some(n), _) => (n.min(ENV_MAX_THREADS), "override"),
-            (None, Some(n)) => (n.min(ENV_MAX_THREADS), "env"),
-            (None, None) => (
-                available
-                    .saturating_mul(DEFAULT_THREADS_PER_CPU)
-                    .min(DEFAULT_MAX_THREADS),
-                "default",
-            ),
-        };
-        (configured.min(work_limit), source)
+        .filter(|&n| n > 0)
+    {
+        (n.min(ENV_MAX_THREADS).min(work_limit), "env")
+    } else {
+        let n = available_cpus
+            .saturating_mul(DEFAULT_THREADS_PER_CPU)
+            .min(DEFAULT_MAX_THREADS)
+            .min(work_limit);
+        (n, "default")
     };
 
     log::debug!(
-        "thread pool: {num_threads} threads (source: {source}, work_items={work_items})"
+        "thread pool: {num_threads} threads (source: {source}, work_items={work_items})",
     );
 
     let pool = rayon::ThreadPoolBuilder::new()

--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -140,9 +140,7 @@ pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
         ThreadSource::Default
     };
 
-    log::debug!(
-        "thread pool: {num_threads} threads (source: {source}, work_items={work_items})",
-    );
+    log::debug!("thread pool: {num_threads} threads (source: {source}, work_items={work_items})",);
 
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)

--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -100,21 +100,25 @@ pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
         .unwrap_or(1)
         .max(1);
 
-    let (num_threads, source) = if let Some(n) = get_num_threads() {
-        (n.min(ENV_MAX_THREADS).min(work_limit), "override")
+    let num_threads;
+    let source;
+    if let Some(n) = get_num_threads() {
+        num_threads = n.min(ENV_MAX_THREADS).min(work_limit);
+        source = "override";
     } else if let Some(n) = std::env::var("DVS_NUM_THREADS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|&n| n > 0)
     {
-        (n.min(ENV_MAX_THREADS).min(work_limit), "env")
+        num_threads = n.min(ENV_MAX_THREADS).min(work_limit);
+        source = "environment";
     } else {
-        let n = available_cpus
+        num_threads = available_cpus
             .saturating_mul(DEFAULT_THREADS_PER_CPU)
             .min(DEFAULT_MAX_THREADS)
             .min(work_limit);
-        (n, "default")
-    };
+        source = "default";
+    }
 
     log::debug!(
         "thread pool: {num_threads} threads (source: {source}, work_items={work_items})",

--- a/dvs/src/utils.rs
+++ b/dvs/src/utils.rs
@@ -6,7 +6,7 @@ const DEFAULT_THREADS_PER_CPU: usize = 4;
 /// Maximum thread count threshold when `DVS_NUM_THREADS` is unset
 const DEFAULT_MAX_THREADS: usize = 16;
 /// Maximum thread count threshold if `DVS_NUM_THREADS` is set
-const ENVIRONMENT_MAX_THREADS: usize = 32;
+const ENV_MAX_THREADS: usize = 32;
 
 /// Global thread count override. 0 = unset (use environment variable or default).
 static NUM_THREADS: AtomicUsize = AtomicUsize::new(0);
@@ -102,9 +102,9 @@ pub fn parse_size(size: &str) -> Result<u64> {
 /// Creates a rayon thread pool with a thread count resolved from a 3-tier
 /// priority chain, each clamped to `work_items`:
 ///
-/// 1. **Override** — `set_num_threads(n)` (capped at `ENVIRONMENT_MAX_THREADS`)
+/// 1. **Override** — `set_num_threads(n)` (capped at `ENV_MAX_THREADS`)
 /// 2. **Environment** — `DVS_NUM_THREADS` environment variable, must parse to
-///    `usize > 0` (capped at `ENVIRONMENT_MAX_THREADS`)
+///    `usize > 0` (capped at `ENV_MAX_THREADS`)
 /// 3. **Default** — `available_cpus * DEFAULT_THREADS_PER_CPU`
 ///    (capped at `DEFAULT_MAX_THREADS`)
 pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
@@ -125,7 +125,7 @@ pub fn get_threadpool(work_items: usize) -> Result<rayon::ThreadPool> {
         .filter(|&n| n > 0);
 
     let num_threads = match (override_threads, environment_threads) {
-        (Some(n), _) | (None, Some(n)) => n.min(ENVIRONMENT_MAX_THREADS).min(work_limit),
+        (Some(n), _) | (None, Some(n)) => n.min(ENV_MAX_THREADS).min(work_limit),
         (None, None) => available_cpus
             .saturating_mul(DEFAULT_THREADS_PER_CPU)
             .min(DEFAULT_MAX_THREADS)

--- a/justfile
+++ b/justfile
@@ -217,11 +217,17 @@ ui-render:
         echo "wrote ${out}"
     done
 
-# Publish ui/output/ui-<NAME>.html to alx with each script as source attachment
-ui-publish-only:
+# Publish ui/output/ui-<NAME>.html to alx with each script as source attachment.
+# No args → publish all ui_names. Args → publish only those names.
+# Examples: `just ui-publish-only`            (all)
+#           `just ui-publish-only threads`    (one)
+#           `just ui-publish-only threads parallel`  (subset)
+ui-publish-only *names:
     #!/usr/bin/env bash
     set -uo pipefail
-    for name in {{ui_names}}; do
+    targets="{{names}}"
+    if [[ -z "$targets" ]]; then targets="{{ui_names}}"; fi
+    for name in $targets; do
         if [[ "$name" == "main" ]]; then script="ui/main.sh"; else script="ui/main_${name}.sh"; fi
         out="ui/output/ui-${name}.html"
         if [[ ! -f "$out" ]]; then echo "skipping ${name} (no ${out})"; continue; fi


### PR DESCRIPTION
<!-- TODO: leading paragraph -->

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
Closes the original investigation: verify that `set_num_threads`'s priority chain resolves identically when called from `dvs-rpkg` as from `dvs-cli`.

**`dvs/src/utils.rs`** (+74/−28): `get_threadpool` now resolves the priority chain (override → environment → default) and emits a `log::debug!` naming the resolved count and the winning tier via a private `ThreadSource` enum (`Override` / `Environment` / `Default`):

```
thread pool: <N> threads (source: override|environment|default, work_items=<W>)
```

Each tier clamps to its own cap (`ENVIRONMENT_MAX_THREADS` / `DEFAULT_MAX_THREADS`) and to `work_items`, co-located inside the match arm so a future edit can't drop a clamp.

**`ui/main_threads.sh`** (new, +229): exercises the chain end-to-end on both interfaces.

- *CLI section* — 4 scenarios: no-flag/no-env default; env-only; `--threads N` beats env; `--threads 0` clears the override.
- *R section* — 5 phases. A–D drive `dvs_add` → `dvs_status` → `dvs_get` under one config each (default / env / option-overrides-env / `withr`-scoped override). Phase E holds `DVS_NUM_THREADS=3` constant and toggles `set_dvs_threads()` between four ops in one repo, so the log line visibly flips `environment → override → override → environment`.

R-side logs render via `set_dvs_log_level("debug")` (possible since #182 routed the cross-thread log queue to R's console).

**`justfile`** (+14/−3):

- `ui_names` adds `threads` so `just ui-run` / `ui-render` / `ui-publish` cover the new script.
- `ui-publish-only` becomes variadic (`*names`): no args publish all; args restrict to those names.

## Local verification (from previous run)
`bash ui/main_threads.sh` produces 20 `thread pool:` log lines; every line's source tier matches its configured input. CLI and R sections drive the same `dvs::utils::get_threadpool` code path, so identical `(N, source)` pairs across the two interfaces confirm the priority chain resolves the same through both bindings.

## Test plan

### Verifying this PR (CLI section)
- [ ] `cargo test -p dvs --lib` passes
- [ ] `just install-cli` rebuilds the dvs binary with the new `log::debug!`
- [ ] CLI section of `ui/main_threads.sh` produces the expected 4 source-tier outcomes

### Env prep needed before the R section of the script runs
The R section needs `dvs-rpkg` rebuilt against this branch's `dvs`. Because `dvs-rpkg/src/rust/Cargo.toml` pins `dvs = { branch = "main" }`, the rpkg won't pick up these changes until this PR lands on main *or* you temporarily re-pin:

- [ ] (temporary) point `dvs-rpkg/src/rust/Cargo.toml`'s `dvs` dep at this branch, or use a local `[patch]` block
- [ ] `cargo update -p dvs --manifest-path dvs-rpkg/src/rust/Cargo.toml`
- [ ] `just rpkg-install`
- [ ] R section of `ui/main_threads.sh` produces 16 log lines with the expected tier transitions
- [ ] `grep -c 'thread pool:' /tmp/ui-threads.log` returns 20

After merge, the temporary pin can be reverted and the rpkg picked up via a normal lockfile bump.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>