### PR TITLE
feat(just): add install-all umbrella recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -134,6 +134,9 @@ vendor-lib crate dev_path:
 
 build-all: build rpkg-build
 
+# Install both the dvs CLI binary and the dvs R package from the current branch
+install-all: install-cli rpkg-install
+
 test-all: test rpkg-test
 
 check-all: check rpkg-check


### PR DESCRIPTION
## Summary

The `ui/main*.sh` scripts have always opened with a NOTE saying
`just install-all` should have been run first, but no such recipe existed —
only `install-cli` and `rpkg-install`. This adds the umbrella so the
banners actually correspond to a real recipe.

## Test plan

- [ ] `just --list` shows `install-all`.
- [ ] `just --show install-all` prints the recipe with both deps resolved.
- [ ] `just install-all` runs `install-cli` followed by `rpkg-install` (slow,
      not part of automated verification — confirmed by inspection of the
      dependency chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)