### PR TITLE
chore(just): drop recursive from ui_names

### DIFF
--- a/justfile
+++ b/justfile
@@ -184,7 +184,7 @@ ci: fmt-check clippy check-std-fs test
 
 # Names correspond to ui/main_<NAME>.sh (and ui/main.sh for "main").
 # Each name has matching ui/output/ui-<NAME>.html and alx topic ui-<NAME>.
-ui_names := "main status progress parallel recursive log"
+ui_names := "main status progress parallel log"
 
 # Run all ui/main*.sh scripts and capture each log into /tmp/ui-<NAME>.log
 ui-run:


### PR DESCRIPTION
## Summary
- `ui/main_recursive.sh` lives only on the unmerged `feat/get-recursive` branch.
- PR #166 added `recursive` to `ui_names` in the justfile without the script, so `just ui-publish` fails on that entry (`alx publish` errors: source file `ui/main_recursive.sh` does not exist).
- Drop it from the list on main; restore when `feat/get-recursive` lands.

## Test plan
- [ ] `just ui-publish` completes without the recursive failure