### PR TITLE
feat(ui): add main_cli_help.sh — clap option-ordering test

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -23,6 +23,7 @@ pub enum Command {
     /// Starts a new dvs project.
     /// This will create a `dvs.toml` file in the current folder of where the user is calling the CLI
     /// from.
+    #[command(next_display_order = 100)]
     Init {
         /// Where the data will be stored
         path: PathBuf,
@@ -42,6 +43,7 @@ pub enum Command {
     /// Adds the given files to dvs. You can use a glob or paths.
     /// If you pass a directory and a glob, the glob will be ran from that directory.
     /// At least one path or --glob must be provided
+    #[command(next_display_order = 100)]
     Add {
         #[clap(required_unless_present = "glob")]
         paths: Vec<PathBuf>,
@@ -55,6 +57,7 @@ pub enum Command {
         dry_run: bool,
     },
     /// Gets the status of each files in the current repository
+    #[command(next_display_order = 100)]
     Status {
         /// Paths (files or directories) to check status for
         paths: Vec<PathBuf>,
@@ -77,6 +80,7 @@ pub enum Command {
     /// Retrieves the given files from dvs storage. You can use a glob or paths.
     /// If you pass a directory and a glob, the glob will be ran from that directory.
     /// At least one path or --glob must be provided
+    #[command(next_display_order = 100)]
     Get {
         #[clap(required_unless_present = "glob")]
         paths: Vec<PathBuf>,
@@ -92,11 +96,11 @@ pub enum Command {
 #[clap(version, author, about, subcommand_negates_reqs = true)]
 pub struct Cli {
     /// Output results as JSON
-    #[clap(long, global = true)]
+    #[clap(long, global = true, display_order = 0)]
     pub json: bool,
 
     /// Number of threads for parallel operations (0 = auto-detect)
-    #[clap(long, global = true)]
+    #[clap(long, global = true, display_order = 1)]
     pub threads: Option<usize>,
 
     #[clap(subcommand)]

--- a/justfile
+++ b/justfile
@@ -184,7 +184,7 @@ ci: fmt-check clippy check-std-fs test
 
 # Names correspond to ui/main_<NAME>.sh (and ui/main.sh for "main").
 # Each name has matching ui/output/ui-<NAME>.html and alx topic ui-<NAME>.
-ui_names := "main status progress parallel log"
+ui_names := "main status progress parallel log cli_help"
 
 # Run all ui/main*.sh scripts and capture each log into /tmp/ui-<NAME>.log
 ui-run:
@@ -226,7 +226,9 @@ ui-publish-only:
         out="ui/output/ui-${name}.html"
         if [[ ! -f "$out" ]]; then echo "skipping ${name} (no ${out})"; continue; fi
         echo "--- alx publish ui-${name} ---"
-        alx publish "$out" -S "$script" -S ui/helpers.sh -t "ui-${name}" \
+        sources=(-S "$script")
+        if grep -q 'helpers\.sh' "$script"; then sources+=(-S ui/helpers.sh); fi
+        alx publish "$out" "${sources[@]}" -t "ui-${name}" \
             --overwrite --skip-warnings --no-prompt 2>&1 | tail -8
     done
 

--- a/ui/main_cli_help.sh
+++ b/ui/main_cli_help.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# CLI help-output ordering test.
+#
+# Goal: verify that `dvs <subcommand> --help` lists options in the order they
+# are declared in dvs-cli/src/main.rs.  The two `Cli`-level globals --json
+# and --threads carry display_order = 0 / 1, and each Command variant sets
+# next_display_order = 100 — so the globals always render at the top of
+# every subcommand's Options section, ahead of the locals.
+#
+# This script prints, for each subcommand:
+#   1. The expected option order — Cli globals first, then locals (in
+#      declaration order from main.rs).
+#   2. The actual `--help` output produced by the installed `dvs` binary.
+# The reader compares the two visually.
+#
+# Unlike the other ui/main_*.sh scripts this one runs without `set -x`:
+# it only prints help text, so xtrace adds noise without value, and the
+# `say` helper from helpers.sh would re-enable xtrace at the end of every
+# call.
+
+set -euo pipefail
+trap 'printf "ERROR at %s:%d\n" "${BASH_SOURCE[0]}" "$LINENO" >&2' ERR
+
+echo "NOTE: \`just install-all\` should have been called prior to this so the dvs CLI binary on PATH reflects the current branch."
+
+# ============================================================================
+# dvs --help — subcommand order
+# ============================================================================
+
+echo
+echo "════════════════════════════════════════════════════════════"
+echo "  dvs --help — subcommand order"
+echo "════════════════════════════════════════════════════════════"
+
+echo
+echo "--- expected (main.rs Command enum, top to bottom; clap appends 'help') ---"
+echo "  init"
+echo "  add"
+echo "  status"
+echo "  get"
+echo "  help"
+
+echo
+echo "--- actual ---"
+dvs --help
+
+# ============================================================================
+# dvs init --help
+# ============================================================================
+
+echo
+echo "════════════════════════════════════════════════════════════"
+echo "  dvs init --help"
+echo "════════════════════════════════════════════════════════════"
+
+echo
+echo "--- expected: Cli globals first, then locals ---"
+echo "  <PATH>"
+echo "  --json"
+echo "  --threads"
+echo "  --root-dir"
+echo "  --metadata-folder-name"
+echo "  --group"
+echo "  --no-compression"
+
+echo
+echo "--- actual ---"
+dvs init --help
+
+# ============================================================================
+# dvs add --help
+# ============================================================================
+
+echo
+echo "════════════════════════════════════════════════════════════"
+echo "  dvs add --help"
+echo "════════════════════════════════════════════════════════════"
+
+echo
+echo "--- expected: Cli globals first, then locals ---"
+echo "  [PATHS]"
+echo "  --json"
+echo "  --threads"
+echo "  --glob"
+echo "  --message"
+echo "  --dry-run"
+
+echo
+echo "--- actual ---"
+dvs add --help
+
+# ============================================================================
+# dvs status --help
+# ============================================================================
+
+echo
+echo "════════════════════════════════════════════════════════════"
+echo "  dvs status --help"
+echo "════════════════════════════════════════════════════════════"
+
+echo
+echo "--- expected: Cli globals first, then locals ---"
+echo "  [PATHS]"
+echo "  --json"
+echo "  --threads"
+echo "  --recursive"
+echo "  --current"
+echo "  --absent"
+echo "  --unsynced"
+echo "  --with-metadata"
+
+echo
+echo "--- actual ---"
+dvs status --help
+
+# ============================================================================
+# dvs get --help
+# ============================================================================
+
+echo
+echo "════════════════════════════════════════════════════════════"
+echo "  dvs get --help"
+echo "════════════════════════════════════════════════════════════"
+
+echo
+echo "--- expected: Cli globals first, then locals ---"
+echo "  [PATHS]"
+echo "  --json"
+echo "  --threads"
+echo "  --glob"
+echo "  --dry-run"
+
+echo
+echo "--- actual ---"
+dvs get --help
+
+echo
+echo "Done. Compare the \"expected\" and \"actual\" blocks above for each subcommand."


### PR DESCRIPTION
<!-- TODO: leading paragraph -->

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
Adds `ui/main_cli_help.sh` (139 lines) — a UI regression test that captures the full `--help` output for `dvs init / add / get / status` so the clap option-ordering layout is pinned down and visible in the published HTML. Anyone refactoring `CommonOpts` / `Cli` / per-command structs has an obvious diff to compare against.

Supporting changes:

**`dvs-cli/src/main.rs`** (+6/−2):
- `#[command(next_display_order = 100)]` on each subcommand variant (`Init`, `Add`, `Status`, `Get`) so per-command options render in a stable order regardless of insertion order.
- `display_order = 0` / `display_order = 1` on the two global flags (`--json`, `--threads`) so they appear at the top of every command's Options section.

**`justfile`** (+4/−2):
- Register `cli_help` in `ui_names` so `just ui-run` / `ui-render` / `ui-publish` pick the new script up.
- `ui-publish-only`: conditionally include `ui/helpers.sh` as a source attachment only when the target script actually sources it. `main_cli_help.sh` deliberately doesn't source `helpers.sh` (no `set -x`, no `say`) so the published log has no xtrace noise.

## History note

Squashed from 10 commits into 1. The intermediate history contained: two abandoned `CommonOpts`-flatten attempts that mutually reverted, a `disable_help_subcommand = true` change that was reverted (the help subcommand row is back), 2 cargo-fmt commits, and a doc-refresh churn that moved to #189. The net diff is small and self-contained.

### Rejected approaches (kept here for posterity)
- `help_heading = "Global Options"`: arbitrary heading text.
- `next_display_order = 1000` on a top-level `GlobalOpts` flatten: arbitrary magic number, restructures globals.
- `CommonOpts` `#[derive(Args)]` flattened into each variant: turns globals from pre-subcommand-allowed into subcommand-only.

## Test plan
- [ ] `just install-all && bash ui/main_cli_help.sh` runs to completion (exit 0)
- [ ] Output makes the ordering match obvious for all four subcommands
- [ ] `just ui-publish` publishes `ui-cli_help` to alx without error
- [ ] `dvs --json <sub>` and `dvs <sub> --json` both work (globals still global)
- [ ] Existing `ui/main_*.sh` scripts continue to pass

## Notes
- Docs refresh for `specs.md` and `dvs-rpkg/CLAUDE.md` was split off into #189.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>