### PR TITLE
fix(paths): handle cwd-relative input in validate_for_add / validate_for_get

### DIFF
--- a/dvs/src/paths.rs
+++ b/dvs/src/paths.rs
@@ -137,8 +137,8 @@ impl DvsPaths {
     pub fn validate_for_add(&self, paths: &[PathBuf]) -> Vec<(PathBuf, AddPathStatus)> {
         let mut found = Vec::new();
         for path in paths {
-            let file_path = self.file_path(path);
-            let status = match file_path.canonicalize() {
+            let repo_rel = self.user_path_to_repo_relative(path);
+            let status = match self.file_path(&repo_rel).canonicalize() {
                 Ok(canonical) => {
                     if !canonical.starts_with(&self.repo_root) {
                         AddPathStatus::OutsideProject
@@ -152,7 +152,7 @@ impl DvsPaths {
                 }
                 Err(_) => AddPathStatus::NotFound,
             };
-            found.push((path.clone(), status));
+            found.push((repo_rel, status));
         }
         found
     }
@@ -160,17 +160,34 @@ impl DvsPaths {
     pub fn validate_for_get(&self, paths: &[PathBuf]) -> Vec<(PathBuf, GetPathStatus)> {
         let mut found = Vec::new();
         for path in paths {
-            let metadata_path = self.metadata_path(path);
-            let validation = if metadata_path.is_file() {
+            let repo_rel = self.user_path_to_repo_relative(path);
+            let validation = if self.metadata_path(&repo_rel).is_file() {
                 GetPathStatus::Tracked
-            } else if self.file_path(path).is_file() {
+            } else if self.file_path(&repo_rel).is_file() {
                 GetPathStatus::NotTracked
             } else {
                 GetPathStatus::NotFound
             };
-            found.push((path.clone(), validation));
+            found.push((repo_rel, validation));
         }
         found
+    }
+
+    /// Convert a user-supplied path (cwd-relative or absolute) to the
+    /// repo-relative form used internally by `file_path` / `metadata_path`.
+    /// Absolute paths outside the repo are returned unchanged so the
+    /// canonicalize-then-starts_with check in `validate_for_add` can flag
+    /// them as `OutsideProject`.
+    fn user_path_to_repo_relative(&self, path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.strip_prefix(&self.repo_root)
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|_| path.to_path_buf())
+        } else if let Some(prefix) = self.cwd_relative_to_root() {
+            prefix.join(path)
+        } else {
+            path.to_path_buf()
+        }
     }
 }
 


### PR DESCRIPTION
The `validate_for_add` / `validate_for_get` path checks expect repo-relative paths, but callers running from a subdir hand them cwd-relative input. Today the cwd→repo-relative conversion lives inside `resolve_paths_for_*`, so any caller that wants per-row `Error` rows (instead of the bail-on-canonicalize-failure behavior) has no way to skip the resolver without losing the conversion. This moves the conversion into the validators themselves so per-row classification works against raw user input. CLI behavior unchanged — it still calls `resolve_paths_for_*`. Required by #193, which uses the per-row form from the R binding.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `validate_for_*` previously did `self.repo_root.join(path)`, which only matched when the caller had already converted to repo-relative form (the side-effect of going through `resolve_paths_for_*`).
- This makes the validators self-sufficient: a new private `DvsPaths::user_path_to_repo_relative` handles the cwd→repo-relative conversion, and the returned tuple carries the repo-relative form so downstream `file_path` / `metadata_path` calls keep working.
- Callers can now hand user input straight to `add_files` / `get_files` and the per-row `AddDetail::Error` / `GetDetail::Error` machinery in `validate_for_*` does the right thing.

## Test plan
- [ ] `cargo test -p dvs --lib` passes (existing `validate_for_add` test covers `Valid` / `NotFound` / `OutsideProject` / `IsDirectory`)
- [ ] `dvs add missing.bin` from a subdir unchanged (CLI still routes through `resolve_paths_for_add` which still bails on canonicalize failure)
- [ ] Companion #193 exercises the new behavior via 12 R-side scenarios in `ui/main_events.sh`

## Notes
- CLI impact: none. The CLI keeps calling `resolve_paths_for_*` which keeps its bail-on-missing behavior. This PR only makes the per-row path usable for callers that want to skip the resolver.
- Required by #193: that PR's rpkg bypasses `resolve_paths_for_*` when no glob is supplied and relies on the per-row classification this PR makes accessible.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>