### PR TITLE
docs: add CLI and R package install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,45 @@ Rewrite of `dvs`, the data-version-control system made by A2-AI.
 
 DVS (Data Version System) is a tool for versioning large or sensitive files under Git without tracking the file content directly.
 
+## Installation
+
+`Cargo.lock` is checked in, so `--locked` builds are reproducible.
+
+### CLI (`dvs` binary)
+
+From a clone:
+
+```sh
+git clone https://github.com/A2-ai/dvs2
+cd dvs2/dvs-cli
+cargo install --path . --force --locked --all-features
+```
+
+Direct from git, no clone:
+
+```sh
+cargo install --git https://github.com/A2-ai/dvs2 --locked --force --all-features dvs-cli
+```
+
+### R package (`dvs`)
+
+From a clone, with [rv](https://github.com/A2-ai/rv):
+
+```sh
+git clone https://github.com/A2-ai/dvs2
+cd dvs2/dvs-rpkg
+rv sync
+Rscript -e 'install.packages(".", repos = NULL, type = "source")'
+```
+
+Direct from git, no clone, with `rv`:
+
+```sh
+rv init
+rv add dvs --git https://github.com/A2-ai/dvs2 --branch main --directory dvs-rpkg
+```
+
+`rv add` requires one of `--branch`, `--tag`, or `--commit`.
 
 ## TODOs
 

--- a/README.md
+++ b/README.md
@@ -10,43 +10,38 @@ DVS (Data Version System) is a tool for versioning large or sensitive files unde
 
 ## Installation
 
-`Cargo.lock` is checked in, so `--locked` builds are reproducible.
-
 ### CLI (`dvs` binary)
 
-From a clone:
-
-```sh
-git clone https://github.com/A2-ai/dvs2
-cd dvs2/dvs-cli
-cargo install --path . --force --locked --all-features
-```
-
-Direct from git, no clone:
+Direct from git:
 
 ```sh
 cargo install --git https://github.com/A2-ai/dvs2 --locked --force --all-features dvs-cli
 ```
 
-### R package (`dvs`)
-
-From a clone, with [rv](https://github.com/A2-ai/rv):
+From a clone:
 
 ```sh
 git clone https://github.com/A2-ai/dvs2
-cd dvs2/dvs-rpkg
-rv sync
-Rscript -e 'install.packages(".", repos = NULL, type = "source")'
+cargo install --path dvs2/dvs-cli --force --locked --all-features
 ```
 
-Direct from git, no clone, with `rv`:
+### R package (`dvs`)
+
+Direct from git, with [rv](https://github.com/A2-ai/rv):
 
 ```sh
 rv init
 rv add dvs --git https://github.com/A2-ai/dvs2 --branch main --directory dvs-rpkg
 ```
 
-`rv add` requires one of `--branch`, `--tag`, or `--commit`.
+From a clone, with `rv`:
+
+```sh
+git clone https://github.com/A2-ai/dvs2
+cd dvs2/dvs-rpkg
+rv sync
+R CMD INSTALL .
+```
 
 ## TODOs
 


### PR DESCRIPTION
<!-- TODO: leading paragraph -->

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Adds an `Installation` section to the top-level `README.md` covering both the `dvs` CLI binary and the `dvs` R package.
- Each surface gets a "direct from git" recipe first, then a "from a clone" recipe.
- CLI from git: `cargo install --git https://github.com/A2-ai/dvs2 --locked --force --all-features dvs-cli`.
- CLI from clone: `git clone ... && cargo install --path dvs2/dvs-cli --force --locked --all-features`.
- R package from git: `rv init && rv add dvs --git ... --branch main --directory dvs-rpkg`.
- R package from clone: `git clone ... && cd dvs2/dvs-rpkg && rv sync && R CMD INSTALL .`.

## Test plan
- [x] `cargo install --git https://github.com/A2-ai/dvs2 --locked --force --all-features dvs-cli` installs the `dvs` binary.
- [x] After `git clone`, `cargo install --path dvs2/dvs-cli --force --locked --all-features` installs the `dvs` binary.
- [x] After `git clone`, `cd dvs2/dvs-rpkg && rv sync && R CMD INSTALL .` builds Rust, generates wrappers, and installs the R package.
- [x] In a fresh dir, `rv init && rv add dvs --git ... --branch main --directory dvs-rpkg` resolves and installs the R package.

## Notes
- `Cargo.lock` is checked in at the workspace root, so `--locked` builds resolve to the committed lockfile.
- `rv add` from a git remote requires one of `--branch`, `--tag`, or `--commit`; the recipe uses `--branch main`.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>