### PR TITLE
chore(rpkg): drop stale module-level comment from lib.rs

### DIFF
--- a/dvs-rpkg/src/rust/lib.rs
+++ b/dvs-rpkg/src/rust/lib.rs
@@ -1,8 +1,6 @@
 //! dvs-rpkg: Data Version Control System R Bindings
 //!
 //! This crate provides R bindings for the DVS (Data Version Control System).
-//! Results are returned as R DataFrames (and Lists) via miniextendr's
-//! `AsSerializeRow` / `ColumnarDataFrame` converters.
 
 mod cli_progress;
 mod test_support;


### PR DESCRIPTION
<!-- TODO: leading paragraph -->

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Drops two `//!` lines from `dvs-rpkg/src/rust/lib.rs` that described the crate's return shape as "R DataFrames (and Lists) via miniextendr's `AsSerializeRow` / `ColumnarDataFrame` converters". The wording predates the current API and the parenthetical "(and Lists)" is now misleading — most `dvs_*` functions return `ColumnarDataFrame`, not `List`.
- Carved out of #149 (spec audit april) as part of the split into focused PRs. Pure mechanical hitchhiker, no spec content here.

## Test plan
- [ ] `just rpkg-clippy -- -D warnings` clean
- [ ] `just rpkg-test` passes

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>