### PR TITLE
docs(spec): drop untracked from file-state model (4 → 3 states)

### DIFF
--- a/specs.md
+++ b/specs.md
@@ -40,9 +40,8 @@ You can pass some arguments to it or edit the toml file manually.
 `status` is a way to check whether everything is checked out or if you have files different from what's in the metadata and
 that you might want to add again.
 
-A file in a `dvs` project can be in 4 states:
+A file in a `dvs` project can be in 3 states:
 
-- `untracked`: not added in `dvs`
 - `current`: tracked in `dvs` and we have the same version as in the metadata folder checked out
 - `absent`: metadata exists in the folder but the local file is not present
 - `unsynced`: local file and metadata exists but the local file differs from the metadata


### PR DESCRIPTION
Updating the `specs.md` to track that in the initial version of dvs2, we will not have the concept of "tracked" files.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `specs.md` claimed "4 states" but only listed 3 valid ones (`current`, `absent`, `unsynced`) plus the obsolete `untracked`. `dvs` no longer surfaces an `untracked` state — `dvs status` operates on tracked files (those with metadata), not on arbitrary files in the project tree.
- Drops the `untracked` bullet and fixes the count.
- Carved out of #149 (spec audit april) as the smallest, lowest-risk slice.

## Test plan
- [ ] specs.md renders cleanly on GitHub
- [ ] `dvs status --help` does not mention `untracked`

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>