### PR TITLE
docs(spec): add high-level conventions — paths, NULL defer

### DIFF
--- a/specs.md
+++ b/specs.md
@@ -46,6 +46,16 @@ A file in a `dvs` project can be in 3 states:
 - `absent`: metadata exists in the folder but the local file is not present
 - `unsynced`: local file and metadata exists but the local file differs from the metadata
 
+### Relative paths vs. absolute paths
+
+All `dvs` commands must accept absolute paths, and whether they need to be within a project scope, or symlinked, or otherwise should be handled by the library. Similarly, relative paths are supported.
+
+### R package
+
+Use `NULL` in `dvs_*` functions, when we want to defer to the default value
+by the library.
+
+
 ## In-depth spec
 
 ### init


### PR DESCRIPTION
Unique design choice, where R API is treating `NULL` as default value by library. This means, that NULL is *not* a fancy way of writing 0, because it may result in non-zero settings.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Adds two short subsections under the "High-level overview" recording rules that already exist in the implementation but were not written down:
  - **Relative paths vs. absolute paths** — every `dvs` command accepts both forms; project-scope / symlink resolution is the library's responsibility, not the caller's.
  - **R package** — pass `NULL` in `dvs_*` functions when you want to defer to the library's default value.
- Carved out of #149 (spec audit april).
- The original spec-audit pass also included a "Rust library must never use `std::io::{Stdin, Stdout, Stderr}`" subsection. **Omitted here on purpose** — the broader no-CLI/no-R-package coupling invariant on the same topic already landed on main via #195 / `9df3750`, and re-stating a narrower form alongside it would just create drift.

## Test plan
- [ ] specs.md renders cleanly on GitHub
- [ ] No `dvs_*` R wrapper in `dvs-rpkg/R/` contradicts the NULL-defer rule
- [ ] No conflict with the library-isolation paragraph already on main

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>