### PR TITLE
fix(audit): store timestamp as jiff::Timestamp (closes #135)

### DIFF
--- a/dvs/src/audit.rs
+++ b/dvs/src/audit.rs
@@ -31,8 +31,6 @@ pub struct AuditFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditEntry {
     pub operation_id: String,
-    /// Stored as a JSON number of whole seconds since the epoch (wire format
-    /// unchanged); typed as `jiff::Timestamp` so consumers don't reconstruct it.
     #[serde(with = "jiff::fmt::serde::timestamp::second::required")]
     pub timestamp: Timestamp,
     pub user: String,

--- a/dvs/src/audit.rs
+++ b/dvs/src/audit.rs
@@ -31,14 +31,17 @@ pub struct AuditFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditEntry {
     pub operation_id: String,
-    pub timestamp: i64,
+    /// Stored as a JSON number of whole seconds since the epoch (wire format
+    /// unchanged); typed as `jiff::Timestamp` so consumers don't reconstruct it.
+    #[serde(with = "jiff::fmt::serde::timestamp::second::required")]
+    pub timestamp: Timestamp,
     pub user: String,
     pub action: Action,
 }
 
 impl AuditEntry {
     pub fn new_add(operation_id: Uuid, file: AuditFile, compression: Compression) -> Self {
-        let timestamp = Timestamp::now().as_second();
+        let timestamp = Timestamp::now();
         let user = whoami::username().unwrap_or_else(|_| "unknown".to_string());
 
         Self {
@@ -50,7 +53,7 @@ impl AuditEntry {
     }
 
     pub fn new_init(operation_id: Uuid, config: Config, project_path: PathBuf) -> Self {
-        let timestamp = Timestamp::now().as_second();
+        let timestamp = Timestamp::now();
         let user = whoami::username().unwrap_or_else(|_| "unknown".to_string());
         let project_path = project_path.canonicalize().unwrap_or(project_path);
 

--- a/dvs/src/backends/local.rs
+++ b/dvs/src/backends/local.rs
@@ -472,7 +472,7 @@ mod tests {
 
         let entry1 = AuditEntry {
             operation_id: "op-1".to_string(),
-            timestamp: 1000000000,
+            timestamp: jiff::Timestamp::from_second(1000000000).unwrap(),
             user: "alice".to_string(),
             action: Action::Add {
                 file: AuditFile {
@@ -485,7 +485,7 @@ mod tests {
 
         let entry2 = AuditEntry {
             operation_id: "op-2".to_string(),
-            timestamp: 2000000000,
+            timestamp: jiff::Timestamp::from_second(2000000000).unwrap(),
             user: "bob".to_string(),
             action: Action::Add {
                 file: AuditFile {
@@ -507,11 +507,12 @@ mod tests {
         assert_eq!(entries.len(), 2);
 
         assert_eq!(entries[0].operation_id, "op-1");
-        assert_eq!(entries[0].timestamp, 1000000000);
+        // i64-seconds wire format still deserializes into a typed Timestamp
+        assert_eq!(entries[0].timestamp.as_second(), 1000000000);
         assert_eq!(entries[0].user, "alice");
 
         assert_eq!(entries[1].operation_id, "op-2");
-        assert_eq!(entries[1].timestamp, 2000000000);
+        assert_eq!(entries[1].timestamp.as_second(), 2000000000);
         assert_eq!(entries[1].user, "bob");
     }
 
@@ -534,7 +535,10 @@ mod tests {
                     for idx in 0..entries_per_worker {
                         let entry = AuditEntry {
                             operation_id: format!("op-{worker}-{idx}"),
-                            timestamp: (worker * entries_per_worker + idx) as i64,
+                            timestamp: jiff::Timestamp::from_second(
+                                (worker * entries_per_worker + idx) as i64,
+                            )
+                            .unwrap(),
                             user: format!("user-{worker}"),
                             action: Action::Add {
                                 file: AuditFile {
@@ -560,7 +564,7 @@ mod tests {
     fn test_audit_entry() -> AuditEntry {
         AuditEntry {
             operation_id: "op-1".to_string(),
-            timestamp: 1000000000,
+            timestamp: jiff::Timestamp::from_second(1000000000).unwrap(),
             user: "alice".to_string(),
             action: Action::Add {
                 file: AuditFile {


### PR DESCRIPTION
Type `AuditEntry.timestamp` as `jiff::Timestamp` instead of a raw `i64`, with no change to the on-disk wire format.

<details>
<summary><h3>AI-written details</h3></summary>

Implements Option A from #135 (the zero-migration pick):
- `#[serde(with = "jiff::fmt::serde::timestamp::second::required")]` keeps the JSON as a bare number of whole seconds — existing `audit.log.jsonl` files deserialize unchanged.
- `AuditEntry.timestamp` is now `jiff::Timestamp`; `new_add`/`new_init` drop the `Timestamp::now().as_second()` flatten.
- The existing `parse_audit_log` test (fixture with `1000000000`/`2000000000`) now asserts via `.as_second()`, which doubles as the wire-compat check (old i64 logs still parse).

`cargo test -p dvs --lib` 68/68, `cargo clippy --workspace` clean. Out of scope (per the issue): `operation_id` stays `String`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
