### PR TITLE
feat(core): lift storage-inside-repo guard into dvs::init (closes #131)

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -1,7 +1,6 @@
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
-use anyhow::bail;
 use anyhow::{Result, anyhow};
 use clap::{Parser, Subcommand};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -213,18 +212,6 @@ fn try_main() -> Result<()> {
             } else {
                 current_dir
             };
-
-            let abs_storage = if storage_path.exists() {
-                std::fs::canonicalize(&storage_path)?
-            } else if let Some(parent) = storage_path.parent().filter(|p| p.exists()) {
-                std::fs::canonicalize(parent)?.join(storage_path.file_name().unwrap())
-            } else {
-                std::path::absolute(&storage_path)?
-            };
-            let abs_root = std::fs::canonicalize(&root)?;
-            if abs_storage.starts_with(&abs_root) {
-                bail!("The given storage path is within the repository.")
-            }
 
             let repo_root = init(&root, config)?;
             if cli.json {

--- a/dvs-rpkg/src/rust/lib.rs
+++ b/dvs-rpkg/src/rust/lib.rs
@@ -171,7 +171,6 @@ pub(crate) fn dvs_init(
         config.set_metadata_folder_name(m);
     }
 
-    // The storage-inside-repo guard now lives in dvs::init::init().
     init(&root_dir, config)?;
 
     r_println!("DVS Initialized");

--- a/dvs-rpkg/src/rust/lib.rs
+++ b/dvs-rpkg/src/rust/lib.rs
@@ -171,19 +171,7 @@ pub(crate) fn dvs_init(
         config.set_metadata_folder_name(m);
     }
 
-    // Mirrors the CLI guard: refuse to store data inside the repo it's versioning.
-    let abs_storage = if storage_path.exists() {
-        std::fs::canonicalize(&storage_path)?
-    } else if let Some(parent) = storage_path.parent().filter(|p| p.exists()) {
-        std::fs::canonicalize(parent)?.join(storage_path.file_name().unwrap())
-    } else {
-        std::path::absolute(&storage_path)?
-    };
-    let abs_root = std::fs::canonicalize(&root_dir)?;
-    if abs_storage.starts_with(&abs_root) {
-        return Err(anyhow!("The given storage path is within the repository."));
-    }
-
+    // The storage-inside-repo guard now lives in dvs::init::init().
     init(&root_dir, config)?;
 
     r_println!("DVS Initialized");

--- a/dvs/src/backends/local.rs
+++ b/dvs/src/backends/local.rs
@@ -198,6 +198,10 @@ impl Backend for LocalBackend {
         Ok(self.path.join(AUDIT_LOG_FILENAME).exists())
     }
 
+    fn local_path(&self) -> Option<&Path> {
+        Some(&self.path)
+    }
+
     fn init(&self) -> Result<()> {
         log::debug!("Creating storage directory: {}", self.path.display());
         fs::create_dir_all(&self.path)?;

--- a/dvs/src/backends/mod.rs
+++ b/dvs/src/backends/mod.rs
@@ -46,4 +46,12 @@ pub trait Backend: Send + Sync {
     /// Read the whole audit file, filtered by the given file paths.
     /// If `files` is empty, return the full audit log
     fn read_audit_file(&self, files: &[PathBuf]) -> Result<Vec<AuditEntry>>;
+
+    /// For backends backed by a local filesystem directory, the storage path.
+    /// `None` for backends where "inside the repository" is not meaningful
+    /// (e.g. a future remote backend). Used by `init` to reject storage that
+    /// lives inside the repo root.
+    fn local_path(&self) -> Option<&Path> {
+        None
+    }
 }

--- a/dvs/src/files/add.rs
+++ b/dvs/src/files/add.rs
@@ -267,14 +267,10 @@ mod tests {
         // Valid file
         create_file(&root, "a.txt", b"a");
 
-        // Outside-project file
-        let outside_tmp = tempfile::tempdir().unwrap();
-        let outside_file = fs::canonicalize(outside_tmp.path())
-            .unwrap()
-            .join("outside.txt");
+        // Outside-project file: a sibling of the repo, outside its root.
+        let outside_file = root.parent().unwrap().join("outside.txt");
         fs::write(&outside_file, b"outside").unwrap();
-        let outside_relative =
-            PathBuf::from("..").join(outside_file.strip_prefix(root.parent().unwrap()).unwrap());
+        let outside_relative = PathBuf::from("..").join("outside.txt");
 
         // Directory inside the repo
         fs::create_dir(root.join("subdir")).unwrap();

--- a/dvs/src/files/get.rs
+++ b/dvs/src/files/get.rs
@@ -436,6 +436,8 @@ mod tests {
 
         // Corrupt the storage file (must remove read-only first)
         let storage_path = root
+            .parent()
+            .unwrap()
             .join(".storage")
             .join(&metadata.hashes.blake3[..2])
             .join(&metadata.hashes.blake3[2..]);

--- a/dvs/src/init.rs
+++ b/dvs/src/init.rs
@@ -12,6 +12,24 @@ use crate::paths;
 /// We need a ready to use Config object + the current directory the user is in
 pub fn init(root_dir: impl AsRef<Path>, config: Config) -> Result<PathBuf> {
     let root_dir = root_dir.as_ref();
+
+    // The storage directory must not live inside the repository, otherwise it
+    // would be tracked alongside the user's files. Only meaningful for local
+    // backends; remote backends report `None` and skip the check.
+    if let Some(storage_path) = config.backend().local_path() {
+        let abs_storage = if storage_path.exists() {
+            fs::canonicalize(storage_path)?
+        } else if let Some(parent) = storage_path.parent().filter(|p| p.exists()) {
+            fs::canonicalize(parent)?.join(storage_path.file_name().unwrap())
+        } else {
+            std::path::absolute(storage_path)?
+        };
+        let abs_root = fs::canonicalize(root_dir)?;
+        if abs_storage.starts_with(&abs_root) {
+            bail!("The given storage path is within the repository.");
+        }
+    }
+
     if root_dir.join(paths::CONFIG_FILE_NAME).exists() {
         bail!("dvs is already initialized (dvs.toml exists)");
     }
@@ -57,7 +75,7 @@ mod tests {
     #[test]
     fn init_creates_config_and_directories() {
         let (_tmp, root) = create_temp_git_repo();
-        let storage = root.join(".storage");
+        let storage = root.parent().unwrap().join(".storage");
 
         let config = Config::new_local(&storage, None).unwrap();
         init(&root, config).unwrap();
@@ -73,7 +91,7 @@ mod tests {
     #[test]
     fn init_logs_audit_entry() {
         let (_tmp, root) = create_temp_git_repo();
-        let storage = root.join(".storage");
+        let storage = root.parent().unwrap().join(".storage");
 
         let config = Config::new_local(&storage, None).unwrap();
         init(&root, config.clone()).unwrap();
@@ -89,7 +107,7 @@ mod tests {
     #[test]
     fn init_fails_if_already_initialized() {
         let (_tmp, root) = create_temp_git_repo();
-        let storage = root.join(".storage");
+        let storage = root.parent().unwrap().join(".storage");
 
         let config = Config::new_local(&storage, None).unwrap();
         init(&root, config.clone()).unwrap();
@@ -102,7 +120,7 @@ mod tests {
     #[test]
     fn init_fails_if_backend_already_initialized() {
         let (_tmp, root) = create_temp_git_repo();
-        let storage = root.join(".storage");
+        let storage = root.parent().unwrap().join(".storage");
 
         let config = Config::new_local(&storage, None).unwrap();
         assert!(!config.backend().is_initialized().unwrap());
@@ -121,9 +139,29 @@ mod tests {
     }
 
     #[test]
+    fn init_rejects_storage_inside_repo() {
+        let (_tmp, root) = create_temp_git_repo();
+        // Storage directory nested inside the repository root.
+        let storage = root.join("inside").join(".storage");
+
+        let config = Config::new_local(&storage, None).unwrap();
+        let result = init(&root, config);
+        assert!(
+            result.is_err(),
+            "init should reject storage inside the repository"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("within the repository"),
+            "error should explain the storage path is inside the repo"
+        );
+        // Nothing should have been created.
+        assert!(!root.join("dvs.toml").exists());
+    }
+
+    #[test]
     fn init_succeeds_in_subdirectory_of_initialized_project() {
         let (_tmp, root) = create_temp_git_repo();
-        let storage = root.join(".storage");
+        let storage = root.parent().unwrap().join(".storage");
 
         // Initialize the parent project
         let config = Config::new_local(&storage, None).unwrap();
@@ -132,7 +170,7 @@ mod tests {
         // Create a subdirectory and initialize a nested project there
         let subdir = root.join("nested");
         fs::create_dir(&subdir).unwrap();
-        let nested_storage = subdir.join(".storage");
+        let nested_storage = root.parent().unwrap().join(".nested-storage");
         let nested_config = Config::new_local(&nested_storage, None).unwrap();
         let result = init(&subdir, nested_config);
         assert!(
@@ -162,7 +200,7 @@ mod tests {
         assert!(!root.join(".dvs").exists(), ".dvs should be cleaned up");
 
         // A retry with a valid storage path should now succeed
-        let valid_storage = root.join(".storage");
+        let valid_storage = root.parent().unwrap().join(".storage");
         let config = Config::new_local(&valid_storage, None).unwrap();
         init(&root, config).unwrap();
         assert!(root.join("dvs.toml").is_file());

--- a/dvs/src/init.rs
+++ b/dvs/src/init.rs
@@ -151,7 +151,10 @@ mod tests {
             "init should reject storage inside the repository"
         );
         assert!(
-            result.unwrap_err().to_string().contains("within the repository"),
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("within the repository"),
             "error should explain the storage path is inside the repo"
         );
         // Nothing should have been created.

--- a/dvs/src/lib.rs
+++ b/dvs/src/lib.rs
@@ -40,7 +40,11 @@ pub mod testutil {
     /// otherwise the directory gets deleted.
     pub fn create_temp_git_repo() -> (TempDir, PathBuf) {
         let tmp = tempfile::tempdir().unwrap();
-        let repo_root = fs::canonicalize(tmp.path()).unwrap();
+        // The repo lives in a subdirectory of the tempdir so that storage can
+        // be placed as a sibling (outside the repo), matching real usage and
+        // the storage-inside-repo guard in `init`.
+        let repo_root = fs::canonicalize(tmp.path()).unwrap().join("repo");
+        fs::create_dir(&repo_root).unwrap();
         fs::create_dir(repo_root.join(".git")).unwrap();
         (tmp, repo_root)
     }
@@ -58,10 +62,11 @@ pub mod testutil {
     }
 
     /// Initializes a DVS repository in the given directory.
-    /// Creates storage at `{repo_root}/.storage` and metadata at `{repo_root}/.dvs`.
+    /// Creates storage at `{repo_root}/../.storage` (a sibling, outside the
+    /// repo) and metadata at `{repo_root}/.dvs`.
     /// Returns (config, dvs_metadata_dir).
     pub fn init_dvs_repo(repo_root: &Path) -> (Config, PathBuf) {
-        let storage_dir = repo_root.join(".storage");
+        let storage_dir = repo_root.parent().unwrap().join(".storage");
         let config = Config::new_local(&storage_dir, None).unwrap();
         init(repo_root, config.clone()).unwrap();
         let dvs_dir = repo_root.join(".dvs");

--- a/dvs/src/paths.rs
+++ b/dvs/src/paths.rs
@@ -196,16 +196,9 @@ mod tests {
         // Valid: existing file inside repo
         fs_err::write(root.join("test.txt"), b"content").unwrap();
 
-        // OutsideProject: file in a sibling temp dir
-        let outside_tmp = tempfile::tempdir().unwrap();
-        let outside_path = fs::canonicalize(outside_tmp.path()).unwrap();
-        fs_err::write(outside_path.join("outside.txt"), b"outside").unwrap();
-        let outside_relative = PathBuf::from("..").join(
-            outside_path
-                .join("outside.txt")
-                .strip_prefix(root.parent().unwrap())
-                .unwrap(),
-        );
+        // OutsideProject: a sibling of the repo, outside its root.
+        fs_err::write(root.parent().unwrap().join("outside.txt"), b"outside").unwrap();
+        let outside_relative = PathBuf::from("..").join("outside.txt");
 
         // IsDirectory: a subdirectory inside the repo
         fs_err::create_dir(root.join("subdir")).unwrap();

--- a/specs.md
+++ b/specs.md
@@ -70,6 +70,9 @@ explore.
 init will always error if a `dvs.toml` already exists in the target directory.
 This check is local: a `dvs.toml` in a parent directory does not prevent initializing a nested project.
 
+init also rejects a storage path inside the repository root. This guard applies to local-filesystem backends.
+Backends with no local directory (such as a future remote backend) skip it.
+
 On partial failure (e.g., metadata folder or storage creation fails after `dvs.toml` is written),
 init attempts best-effort cleanup of local artifacts (`dvs.toml` and, if it didn't exist beforehand, the metadata folder) so that a retry is possible.
 


### PR DESCRIPTION
Lifts the "storage path must not live inside the repo root" check out of the two front-ends and into the core crate, so every caller inherits the invariant.

## What changed
- `Backend::local_path() -> Option<&Path>` (defaulted to `None`); `LocalBackend` returns its storage path.
- `dvs::init::init()` runs the guard up front, gated on `local_path()` — backends with no local directory (e.g. a future remote) skip it.
- Dropped the duplicated guard blocks from `dvs-cli` `Command::Init` and `dvs-rpkg` `dvs_init`.
- New unit test `init_rejects_storage_inside_repo`.

Closes #131.

<details><summary><h3>AI-written details</h3></summary>

### Test-fixture change
The core test fixtures placed `.storage` *inside* the repo root — an arrangement the guard (correctly) rejects, and the reason lifting the guard initially broke 6+ tests. `create_temp_git_repo` now nests the repo at `{tempdir}/repo` so storage can live as a sibling (`{tempdir}/.storage`), matching real usage. Updated `init_dvs_repo`, the `init` unit tests, and the two `validate_for_add` / `add_files_mixed_statuses` tests that derived an "outside project" path from `root.parent()`.

### Merge note
The `dvs-rpkg/src/rust/lib.rs` hunk (removing the guard from `dvs_init`) will conflict with #207's re-scaffold, which rewrites the same function. Resolve by keeping both changes: #207's new FFI body **without** the storage guard block.

### Verification
`cargo test -p dvs -p dvs-cli` → 69 passed. `cargo clippy -p dvs -p dvs-cli` → clean. rpkg not built locally (no R toolchain in this environment); the rpkg change is a pure deletion with no orphaned imports (`anyhow!`/`storage_path` still used elsewhere in the function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>

<details>
<summary><h4>AI-added: spec follow-up (do in this PR)</h4></summary>

- [x] specs.md (init section): document that `init` rejects a storage path inside the repository root (local-filesystem backends only, remote backends skip the check).

This keeps `specs.md` aligned with the behavior this PR introduces, so the spec change lands with the code instead of drifting in a separate PR.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>

