### PR TITLE
fix(rpkg): show progress bar only in interactive sessions (closes #118)

### DIFF
--- a/dvs-rpkg/R/dvs-commands.R
+++ b/dvs-rpkg/R/dvs-commands.R
@@ -30,7 +30,9 @@ dvs_add <- function(
 ) {
   dvs_set_threads_impl(getOption("dvs.num_threads"))
   progress_callback <- NULL
-  if (!isTRUE(dry_run)) {
+  # Only show a progress bar in interactive sessions; non-interactive callers
+  # should prefer dvs-cli (see #118).
+  if (!isTRUE(dry_run) && interactive()) {
     progress_callback <- ProgressBarCallback$new()
   }
 
@@ -83,7 +85,9 @@ dvs_status <- function(
 dvs_get <- function(paths = character(0), glob = NULL, dry_run = NULL) {
   dvs_set_threads_impl(getOption("dvs.num_threads"))
   progress_callback <- NULL
-  if (!isTRUE(dry_run)) {
+  # Only show a progress bar in interactive sessions; non-interactive callers
+  # should prefer dvs-cli (see #118).
+  if (!isTRUE(dry_run) && interactive()) {
     progress_callback <- ProgressBarCallback$new()
   }
 


### PR DESCRIPTION
`dvs_add` and `dvs_get` created a `ProgressBarCallback` whenever the call wasn't a dry run, so progress bars rendered in non-interactive contexts (scripts, Rmd/Quarto renders, CI) where they're just noise. Now gated on `interactive()`.

```r
if (!isTRUE(dry_run) && interactive()) {
  progress_callback <- ProgressBarCallback$new()
}
```

Non-interactive callers should prefer dvs-cli, as the issue notes.

Closes #118.

<details><summary><h3>AI-written details</h3></summary>

### Scope
Two call sites in hand-written `dvs-rpkg/R/dvs-commands.R` (`dvs_add`, `dvs_get`). No change to the generated `dvs-wrappers.R`, the Rust FFI, or any signature — so no re-scaffold/re-document needed, and no conflict with #207's re-scaffold.

### Verification
`parse()` of the edited R file succeeds. Not built/loaded with the full R toolchain in this environment; the change is a one-condition guard using base `interactive()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>