### PR TITLE
docs(spec): sync help/signatures + corrections from claim audit

### DIFF
--- a/specs.md
+++ b/specs.md
@@ -417,10 +417,17 @@ The threadpool size set directly by the R package takes precedence over the
 
 ### Gitignore
 
-After a successful `add`, each added file is appended to a `.gitignore` in the file's parent directory
-using the format `/<filename>` unless it's already present. If the repository has no `.git` folder, gitignore
-updates are skipped entirely. A failure to update `.gitignore` is logged as a warning but does not cause
-the `add` operation to fail.
+After a successful `add`, `dvs` updates per-directory `.gitignore` files so the data files stay out of Git while
+the `.dvs` metadata stays tracked. Two kinds of entries are written:
+
+- Each added data file gets a `/<filename>` entry (the basename, anchored with a leading `/`) in the `.gitignore`
+  of that file's own directory. The file's path selects which `.gitignore` is used. For example, `data/input.csv`
+  adds `/input.csv` to `data/.gitignore`, and a file at the project root uses the root `.gitignore`.
+- The hash cache inside the metadata folder is ignored too. When the cache is first created, a `/.cache` entry is
+  added to the metadata folder's `.gitignore` (by default `.dvs/.gitignore`).
+
+Entries already present are not duplicated. If the repository has no `.git` folder, gitignore updates are skipped
+entirely. A failure to update a `.gitignore` is logged as a warning but does not cause the `add` operation to fail.
 
 ### Globbing
 

--- a/specs.md
+++ b/specs.md
@@ -166,7 +166,7 @@ Options:
 ```
 
 You can run `dvs add *.csv` and it will be expanded by your shell before calling `dvs`.
-To ensure globs are consistent with the R package, you can use the `--glob` parameter which will be expanded by the library.
+To ensure globs are consistent with the R package, you can use the `--glob` parameter which will be expanded by the library. The glob string must be quoted (for example `--glob '*.csv'`) so the shell does not expand it before `dvs` sees it.
 
 This will exit with `1` if one or more files could not be added to the storage (file does not exist, no permissions, etc).
 

--- a/specs.md
+++ b/specs.md
@@ -85,12 +85,12 @@ Arguments:
 Options:
       --json
           Output results as JSON
+      --threads <THREADS>
+          Number of threads for parallel operations (0 = auto-detect)
       --root-dir <ROOT_DIR>
           If you want to use a root folder other than the current directory
       --metadata-folder-name <METADATA_FOLDER_NAME>
           If you want to use a folder name other than `.dvs` for storing the metadata files
-      --threads <THREADS>
-          Number of threads for parallel operations (0 = auto-detect)
       --group <GROUP>
           Unix group to set on storage directory and files
       --no-compression
@@ -157,10 +157,10 @@ Arguments:
   [PATHS]...  
 
 Options:
-      --glob <GLOB>        
       --json               Output results as JSON
-  -m, --message <MESSAGE>  An optional message to add
       --threads <THREADS>  Number of threads for parallel operations (0 = auto-detect)
+      --glob <GLOB>        
+  -m, --message <MESSAGE>  An optional message to add
       --dry-run            Show what would be added without making any actual changes
   -h, --help               Print help
 ```
@@ -221,10 +221,10 @@ Arguments:
   [PATHS]...  
 
 Options:
-  -g, --glob <GLOB>        
       --json               Output results as JSON
-      --dry-run            Show what would be retrieved without making any actual changes
       --threads <THREADS>  Number of threads for parallel operations (0 = auto-detect)
+  -g, --glob <GLOB>        
+      --dry-run            Show what would be retrieved without making any actual changes
   -h, --help               Print help
 ```
 
@@ -268,9 +268,9 @@ Arguments:
 
 Options:
       --json               Output results as JSON
+      --threads <THREADS>  Number of threads for parallel operations (0 = auto-detect)
   -r, --recursive          Recursively include files in subdirectories for given directories
       --current            Include the files that are current
-      --threads <THREADS>  Number of threads for parallel operations (0 = auto-detect)
       --absent             Include the files that are absent
       --unsynced           Include the files that are unsynced
       --with-metadata      Show all metadata columns in the table output
@@ -297,6 +297,7 @@ dvs_status(
 ```
 
 - `paths` optional vector of paths files to retrieve status of
+- `recursive` if `TRUE`, recursively include files in subdirectories for any directory paths
 - `status` represent the filter flags `current`, `absent`, `unsynced`
   When omitted, all three states are present in the returned data-frame, otherwise serval filtering status can be provided
 

--- a/specs.md
+++ b/specs.md
@@ -133,6 +133,11 @@ message that will be recorded in the metadata file. Similarly, `add` must not ha
 This method follows a best-effort approach: even if some files failed to be added, it will still try to add everything
 and not stop.
 
+Each added file produces a metadata sidecar in the metadata folder (by default `.dvs`), mirroring the file path with a
+`.dvs` suffix. For example, adding `data/input.csv` writes `.dvs/data/input.csv.dvs`. These sidecar files are small and
+must be committed to version control, since they are what lets collaborators run `get` to retrieve the data. The data
+file itself is added to `.gitignore` instead. See the Metadata file format section for the full schema.
+
 Each file in an `add` result reports an outcome:
 
 - `copied`: the file was new or had changed and was copied to storage

--- a/specs.md
+++ b/specs.md
@@ -431,7 +431,4 @@ the `add` operation to fail.
 - No given paths with a glob: walks current directory filtered by glob
 
 Globs use a literal path separator, meaning `*.csv` only matches files in the target directory and
-will not match `subdir/file.csv`. Use `**/*.csv` to match recursively across subdirectories.
-
-On the CLI, the glob string passed to `--glob` must be quoted (for example `--glob '**/*.csv'`) so the shell does not
-expand it before `dvs` sees it.
+will not match `subdir/file.csv`. Use `'**/*.csv'` (quoted, to avoid shell expansion) to match recursively across subdirectories.

--- a/specs.md
+++ b/specs.md
@@ -37,6 +37,8 @@ You can pass some arguments to it or edit the toml file manually.
 
 `get` will retrieve the files thanks to the metadata folder and pull them from the storage to their location in the project.
 
+Both `add` and `get` support a dry run from the CLI, the library, or the R package, returning the outcome that would have happened for each file without actually doing it.
+
 `status` is a way to check whether everything is checked out or if you have files different from what's in the metadata and
 that you might want to add again.
 
@@ -142,9 +144,6 @@ Symlinks are resolved before adding. If a symlink target resolves to a path outs
 Each `add` operation is atomic: the storage write and metadata update either both succeed or both roll back. A
 failure writing to storage will not leave behind a partial metadata file, and vice versa.
 
-You can also do a dry run from the CLI,the library, or R package that will return the outcome that would have happened for each file but
-without actually doing them.
-
 #### CLI
 
 ```shell
@@ -205,9 +204,6 @@ is deleted and the operation fails for that file.
 
 Users can use `get` with specific paths or globs. In practice those will be ran on the metadata folder rather
 than the actual project, to know what to pull but the resolution works the same way as `add`.
-
-You can also do a dry run from the CLI, R package or the library that will return the outcome that would have happened for each file but
-without actually doing them.
 
 #### CLI
 

--- a/specs.md
+++ b/specs.md
@@ -418,16 +418,12 @@ The threadpool size set directly by the R package takes precedence over the
 ### Gitignore
 
 After a successful `add`, `dvs` updates per-directory `.gitignore` files so the data files stay out of Git while
-the `.dvs` metadata stays tracked. Two kinds of entries are written:
-
-- Each added data file gets a `/<filename>` entry (the basename, anchored with a leading `/`) in the `.gitignore`
-  of that file's own directory. The file's path selects which `.gitignore` is used. For example, `data/input.csv`
-  adds `/input.csv` to `data/.gitignore`, and a file at the project root uses the root `.gitignore`.
-- The hash cache inside the metadata folder is ignored too. When the cache is first created, a `/.cache` entry is
-  added to the metadata folder's `.gitignore` (by default `.dvs/.gitignore`).
-
-Entries already present are not duplicated. If the repository has no `.git` folder, gitignore updates are skipped
-entirely. A failure to update a `.gitignore` is logged as a warning but does not cause the `add` operation to fail.
+the `.dvs` metadata stays tracked. Each added data file gets a `/<filename>` entry (the basename, anchored with a
+leading `/`) in the `.gitignore` of that file's own directory, so the file's path selects which `.gitignore` is
+used. For example, `data/input.csv` adds `/input.csv` to `data/.gitignore`, and a file at the project root uses the
+root `.gitignore`. Entries already present are not duplicated. If the repository has no `.git` folder, gitignore
+updates are skipped entirely. A failure to update a `.gitignore` is logged as a warning but does not cause the `add`
+operation to fail.
 
 ### Globbing
 

--- a/specs.md
+++ b/specs.md
@@ -422,13 +422,9 @@ The threadpool size set directly by the R package takes precedence over the
 
 ### Gitignore
 
-After a successful `add`, `dvs` updates per-directory `.gitignore` files so the data files stay out of Git while
-the `.dvs` metadata stays tracked. Each added data file gets a `/<filename>` entry (the basename, anchored with a
-leading `/`) in the `.gitignore` of that file's own directory, so the file's path selects which `.gitignore` is
-used. For example, `data/input.csv` adds `/input.csv` to `data/.gitignore`, and a file at the project root uses the
-root `.gitignore`. Entries already present are not duplicated. If the repository has no `.git` folder, gitignore
-updates are skipped entirely. A failure to update a `.gitignore` is logged as a warning but does not cause the `add`
-operation to fail.
+After a successful `add`, each data file gets a `/<filename>` entry in its own directory's `.gitignore`, keeping the
+data out of Git while the `.dvs` metadata stays tracked. Existing entries are not duplicated. If there is no `.git`
+folder the update is skipped, and a failed `.gitignore` update is logged as a warning without failing the `add`.
 
 ### Globbing
 

--- a/specs.md
+++ b/specs.md
@@ -133,10 +133,8 @@ message that will be recorded in the metadata file. Similarly, `add` must not ha
 This method follows a best-effort approach: even if some files failed to be added, it will still try to add everything
 and not stop.
 
-Each added file produces a metadata sidecar in the metadata folder (by default `.dvs`), mirroring the file path with a
-`.dvs` suffix. For example, adding `data/input.csv` writes `.dvs/data/input.csv.dvs`. These sidecar files are small and
-must be committed to version control, since they are what lets collaborators run `get` to retrieve the data. The data
-file itself is added to `.gitignore` instead. See the Metadata file format section for the full schema.
+Each added file gets a metadata sidecar at `<metadata folder>/<path to file>.dvs` (metadata folder defaults to
+`.dvs`), mirroring the added file. The sidecar must be committed to version control. The data file itself is gitignored.
 
 Each file in an `add` result reports an outcome:
 

--- a/specs.md
+++ b/specs.md
@@ -134,7 +134,7 @@ This method follows a best-effort approach: even if some files failed to be adde
 and not stop.
 
 Each added file gets a metadata sidecar at `<metadata folder>/<path to file>.dvs` (metadata folder defaults to
-`.dvs`), mirroring the added file. The sidecar must be committed to version control. The data file itself is gitignored.
+`.dvs`), mirroring the added file. The sidecar must be committed to version control (e.g. `git`). The data file itself is gitignored.
 
 Each file in an `add` result reports an outcome:
 
@@ -279,6 +279,8 @@ Options:
 By default (no flags), `dvs status` shows all tracked files regardless of state. The `--current`, `--absent`, and
 `--unsynced` flags are filters: when one or more are provided, only files matching those states are shown.
 
+This will exit with `1` if one or more files could not be inspected.
+
 #### Rust library
 
 The library scans all metadata files in the project and returns a result for each one. Like `add` and `get`,
@@ -356,18 +358,23 @@ affect previously added files.
 
 ### Audit trail
 
-Every `add` operation is logged to an append-only audit file (`audit.log.jsonl`) in the storage directory. Each
-entry records:
+Every `add` and `init` operation is logged to an append-only audit file (`audit.log.jsonl`) in the storage directory.
+Each entry records:
 
-- `operation_id`: a UUID grouping all files from one `add` invocation
+- `operation_id`: a UUID grouping all files from one operation
 - `timestamp`: unix seconds
 - `user`: the system username of whoever ran the command
-- `action`: currently only `add`
+- `action`: either `add` or `init`
 
-`add` is an object that contains
+The `add` action is an object that contains
 
 - `file`: path and hashes of the added file
 - `compression`: `"zstd"` or `"none"`, see the Compression section
+
+The `init` action is an object that contains
+
+- `settings`: the project configuration written to `dvs.toml`
+- `project_path`: the absolute path of the initialized project
 
 The audit log is protected by a mutex so a single `dvs` process cannot corrupt it but there is no protection against
 multiple processes appending logs.

--- a/specs.md
+++ b/specs.md
@@ -432,3 +432,6 @@ the `add` operation to fail.
 
 Globs use a literal path separator, meaning `*.csv` only matches files in the target directory and
 will not match `subdir/file.csv`. Use `**/*.csv` to match recursively across subdirectories.
+
+On the CLI, the glob string passed to `--glob` must be quoted (for example `--glob '**/*.csv'`) so the shell does not
+expand it before `dvs` sees it.


### PR DESCRIPTION
<TODO: your framing paragraph>

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- CLI `--help` blocks (init/add/get/status): reorder `--threads`/`--json` to match real clap output (global flags render near the top). No options added or removed.
- `dvs_status`: add the missing `recursive` argument bullet (it was in the signature, undocumented).
- Globbing: note the `--glob` string must be quoted to avoid shell expansion (in the add section and the Globbing section).
- High-level overview: dedupe the dry-run note (it was repeated in add and get) into a single sentence scoped to `add`/`get`.
- add section: document the `.dvs` metadata sidecar (`<metadata folder>/<path to file>.dvs`, mirrors the added file, must be committed to version control e.g. `git`, data file is gitignored).
- Gitignore section: correct it to describe the per-directory `/<filename>` placement (the file path selects which `.gitignore`).
- Audit trail: actions are `add` OR `init` (init records `settings` + `project_path`), not "currently only add" (`audit.rs:14-23`, `init.rs:43-46`).
- status: document the CLI exit code 1 when a file cannot be inspected (`main.rs:338-340`).

## Test plan
- [ ] `grep -c '—\|;' specs.md` returns 0 (house style: no em-dashes or semicolons)
- [ ] CLI help blocks match `cargo run -p dvs-cli -- <cmd> --help`
- [ ] claims cross-checked against code (see SPEC-AUDIT.md working notes)

## Notes
- Scope is the merged `specs.md` only. Four further spec edits are tied to in-flight code PRs (#213 init storage guard, #170 dvs_init return, #193 R return shapes, #203/#204 get --recursive) and are tracked in those PRs' descriptions instead, to land with the code.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>