### PR TITLE
docs(audit): document that an empty file filter returns the whole log

### DIFF
--- a/dvs/src/audit.rs
+++ b/dvs/src/audit.rs
@@ -67,6 +67,11 @@ impl AuditEntry {
     }
 }
 
+/// Parse an audit log into entries, optionally filtered to specific files.
+///
+/// An empty `only_files` set returns every entry, that is the whole log. A
+/// non-empty set keeps only `Add` entries whose path is in the set and drops
+/// all `Init` entries.
 pub fn parse_audit_log(
     reader: impl BufRead,
     only_files: &HashSet<PathBuf>,

--- a/dvs/src/backends/local.rs
+++ b/dvs/src/backends/local.rs
@@ -286,6 +286,8 @@ impl Backend for LocalBackend {
         Ok(())
     }
 
+    /// An empty `files` slice returns the full audit log. See
+    /// [`parse_audit_log`] for the filtering rules.
     fn read_audit_file(&self, files: &[PathBuf]) -> Result<Vec<AuditEntry>> {
         let files_to_include: HashSet<_> = HashSet::from_iter(files.iter().cloned());
         let audit_path = self.path.join(AUDIT_LOG_FILENAME);


### PR DESCRIPTION
<!-- TODO: replace with your framing paragraph -->
_Documents the empty-filter-means-all behavior on `parse_audit_log` and `read_audit_file`, confirmed by testing. Docs-only, no behavior change._

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `parse_audit_log`: documents that an empty `only_files` set returns every entry, and that a non-empty set keeps only matching `Add` entries and drops `Init`.
- `LocalBackend::read_audit_file`: documents that an empty `files` slice returns the full log, linking to `parse_audit_log` for the filtering rules.
- No behavior change. Verified empirically: a repo with `init` + N `add` operations produces a raw `audit.log.jsonl` whose line count equals the row count returned for an empty filter.

## Test plan
- [ ] `cargo check -p dvs` clean
- [ ] `cargo doc -p dvs --no-deps` resolves the intra-doc link with no warnings

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>