### PR TITLE
fix(storage): serialize identical-content blob writes (#216)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = [
 description = 'This package allows users to version large or sensitive files under Git without tracking the file directly.'
 license = 'MIT'
 edition = '2024'
-rust-version = '1.85'
+rust-version = '1.89'
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/dvs/src/backends/local.rs
+++ b/dvs/src/backends/local.rs
@@ -223,6 +223,21 @@ impl Backend for LocalBackend {
             self.ensure_group_and_mode(&self.path, self.dir_mode())?;
             self.ensure_group_and_mode(parent, self.dir_mode())?;
         }
+        // Serialize writers targeting the same blob with an exclusive lock on a
+        // per-hash lockfile. Two parallel writes of identical content hash to the
+        // same final path; without this they share `<hash>.tmp` and race on the
+        // rename (one wins, the loser's tmp is already gone -> #216). Distinct
+        // content uses a different lockfile, so unrelated writes still run in
+        // parallel. The lock covers in-process threads and concurrent dvs
+        // processes (advisory flock; best-effort on NFS).
+        let lock = std::fs::File::create(path.with_extension("lock"))?;
+        lock.lock()?;
+
+        // Another writer may have already stored this exact blob while we waited.
+        if path.is_file() {
+            return Ok(fs::metadata(&path)?.len());
+        }
+
         let tmp_path = path.with_extension("tmp");
         let stored_size = compression.compress(source, &tmp_path, on_bytes)?;
 
@@ -361,6 +376,42 @@ mod tests {
         let stored = storage.join("d4").join("1d8cd98f00b204e9800998ecf8427e");
         assert!(stored.is_file());
         assert_eq!(fs::read(&stored).unwrap(), b"test content");
+    }
+
+    #[test]
+    fn concurrent_store_of_identical_content_does_not_race() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = tmp.path().join("storage");
+        let backend = Arc::new(LocalBackend::new(&storage, None).unwrap());
+        backend.init().unwrap();
+
+        // Identical content => identical hash => same final blob path for every
+        // writer. Pre-fix, parallel writers shared `<hash>.tmp` and the losers
+        // failed the rename (#216).
+        let hash = test_hash("d41d8cd98f00b204e9800998ecf8427e");
+
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let backend = Arc::clone(&backend);
+                let src = tmp.path().join(format!("src{i}.bin"));
+                fs::write(&src, b"identical content").unwrap();
+                let hash = hash.clone();
+                thread::spawn(move || backend.store(&hash, &src, Compression::None, None))
+            })
+            .collect();
+
+        for h in handles {
+            h.join()
+                .unwrap()
+                .expect("every concurrent store must succeed");
+        }
+
+        let stored = storage.join("d4").join("1d8cd98f00b204e9800998ecf8427e");
+        assert!(stored.is_file());
+        assert_eq!(fs::read(&stored).unwrap(), b"identical content");
     }
 
     #[test]


### PR DESCRIPTION
Re-verified #216 on a clean `origin/main` build: `dvs add a.bin b.bin` with byte-identical content still fails under the default threadpool (one file errors `failed to rename ... .tmp ...: No such file or directory`, exit 1), while `--threads 1` succeeds. Confirmed real, still present.

<details>
<summary>AI-generated details (reviewed by me)</summary>

**Root cause.** `LocalBackend::store` computed `tmp_path = <hash>.tmp` from the content hash, so two parallel workers storing identical content wrote the *same* temp file and raced on `fs::rename(tmp, final)`. The winner renamed it away; the loser's `rename` found no temp file.

**Fix.** Hold an exclusive lock on a per-hash `<hash>.lock` file (`std::fs::File::lock`, stable since 1.89) across the write+rename. Identical content serializes; distinct content locks a different file and still runs in parallel. A writer that finds the blob already present after acquiring the lock reuses it. Workspace MSRV bumped `1.85 -> 1.89` for `File::lock`.

**Verification.**
- Repro loop (default threads, 1 MiB identical files) — 5/5 runs exit 0 after the fix (was failing pre-fix); both dedup to a single blob, no stray `.tmp`.
- New unit test `concurrent_store_of_identical_content_does_not_race` (8 threads, same hash).
- `cargo test -p dvs backends::local` — 12 pass.

**Tradeoff.** One inert `<hash>.lock` sidecar persists per blob in storage (removing it would re-introduce a race). flock is advisory and best-effort over NFS; the reported in-process race is fully covered regardless.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)