### PR TITLE
fix(status): cwd-scope a bare --glob; document the flag (#218)

### DIFF
--- a/dvs/src/files/status.rs
+++ b/dvs/src/files/status.rs
@@ -73,19 +73,27 @@ pub fn get_status(
         return Ok(Vec::new());
     }
 
+    // A bare glob with no explicit paths anchors to the cwd, matching `add` and
+    // `get` (specs.md Globbing section). Without this the glob matched against
+    // the full repo-relative path, so from a subdirectory `status --glob` globbed
+    // the repo root while `get --glob` globbed the cwd.
+    let cwd_filter = match (filter, glob_pattern) {
+        (None, Some(_)) => Some(PathFilter::cwd_scoped(false, paths)),
+        _ => None,
+    };
+    let filter = filter.or(cwd_filter.as_ref());
+
     let pool = get_threadpool(entries.len())?;
 
     let mut results: Vec<FileStatus> = pool.install(|| {
         entries
             .into_par_iter()
             .filter_map(|relative| {
-                // With a filter, the glob is anchored to the matched path; with
-                // no filter (whole repo) the glob still applies, matched against
-                // the full repo-relative path. This keeps a glob from being
-                // silently ignored when `filter` is `None`.
+                // With a filter the glob is anchored to the matched path. With no
+                // filter and no glob, every tracked file is kept.
                 let keep = match filter {
                     Some(f) => f.matches(&relative, glob.as_ref()),
-                    None => glob.as_ref().is_none_or(|g| g.is_match(&relative)),
+                    None => true,
                 };
                 if !keep {
                     return None;
@@ -447,6 +455,35 @@ mod tests {
         // `**/*.txt` reaches every tracked file.
         let statuses = get_status(&paths, None, Some("**/*.txt")).unwrap();
         assert_eq!(statuses.len(), 4);
+    }
+
+    #[test]
+    fn status_bare_glob_anchors_to_cwd_subdir() {
+        let (_tmp, paths) = setup_filtered_repo();
+        let root = paths.repo_root().to_path_buf();
+        // cwd = dir1: a bare glob must scope to the cwd (like add/get), not the
+        // repo root. Pre-fix it globbed the whole repo from any directory.
+        let sub =
+            DvsPaths::new(fs::canonicalize(root.join("dir1")).unwrap(), root, ".dvs").unwrap();
+
+        // Literal separator: only the direct child dir1/b.txt, not a.txt/dir2.
+        let got: Vec<_> = get_status(&sub, None, Some("*.txt"))
+            .unwrap()
+            .into_iter()
+            .map(|f| f.path)
+            .collect();
+        assert_eq!(got, vec![PathBuf::from("dir1/b.txt")]);
+
+        // Recursive glob reaches dir1/sub/c.txt, still scoped under dir1.
+        let got: Vec<_> = get_status(&sub, None, Some("**/*.txt"))
+            .unwrap()
+            .into_iter()
+            .map(|f| f.path)
+            .collect();
+        assert_eq!(
+            got,
+            vec![PathBuf::from("dir1/b.txt"), PathBuf::from("dir1/sub/c.txt")]
+        );
     }
 
     #[test]

--- a/specs.md
+++ b/specs.md
@@ -287,6 +287,7 @@ Options:
       --json               Output results as JSON
       --threads <THREADS>  Number of threads for parallel operations (0 = auto-detect)
   -r, --recursive          Recursively include files in subdirectories for given directories
+  -g, --glob <GLOB>        
       --current            Include the files that are current
       --absent             Include the files that are absent
       --unsynced           Include the files that are unsynced


### PR DESCRIPTION
Re-verifying #218 on clean `origin/main`, the premise has flipped: `dvs status` **does** accept `-g, --glob` now and globs the metadata folder (literal-sep + recursive). The issue was filed when it did not. Two real gaps remain, fixed here.

> ⚠️ This supersedes PR #221, which edits the spec to say "status does not accept --glob" — that is no longer true on `origin/main`. Recommend closing #221 in favor of this.

<details>
<summary>AI-generated details (reviewed by me)</summary>

**Verified on origin/main (8288f85):**
- `status --glob '*.bin'` / `-g` is accepted and globs metadata (`*.bin` → top-level only, `**/*.bin` → recursive). The flag works.
- **Gap 1 (behavior, N2):** a bare glob with no explicit paths was matched against the full repo-relative path (root-anchored). From `sub/`, `status --glob '*.bin'` globbed the repo root (matched `top.bin`) while `get --glob '*.bin'` globbed the cwd (matched `sub/a.bin`). specs.md Globbing says "No given paths with a glob: walks current directory" → `status` was the deviant.
- **Gap 2 (docs, N4):** the binary's `status --help` lists `-g, --glob <GLOB>` but the specs.md `status --help` block omitted the line.

**Fix.**
- `get_status` anchors the no-paths glob case to the cwd via `PathFilter::cwd_scoped`, matching `add`/`get`. Plain `status` (no paths, no glob) still lists every tracked file.
- Add the `-g, --glob <GLOB>` line to the specs.md `status --help` block.

**Verification.**
- From `sub/`: `status --glob '*.bin'` now returns `sub/a.bin` (parity with `get --glob`). From root, `*.bin` returns only top-level. Plain `status` unchanged.
- New unit test `status_bare_glob_anchors_to_cwd_subdir`; `cargo test -p dvs files::status` → 13 pass.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)