### PR TITLE
docs(spec): clarify get exit-code semantics (closes #220)

### DIFF
--- a/specs.md
+++ b/specs.md
@@ -244,7 +244,10 @@ Options:
 Passing `-r, --recursive` with an explicit directory walks its subdirectories. It only constrains paths given
 explicitly, so an empty path list still returns every tracked file.
 
-This will exit with `1` if one or more files could not be retrieved.
+This exits with `1` when a matched file fails to retrieve (its storage blob is missing or fails the
+hash check) or when nothing matches at all ("No files to get"). Paths are resolved against the metadata
+folder, so an explicitly listed path that is not tracked produces no result and is silently skipped. It
+does not on its own cause a non-zero exit.
 
 #### Rust library
 


### PR DESCRIPTION
Closes #220. Re-verified on clean `origin/main`: `dvs get <tracked> <unknown>` retrieves the tracked file and exits 0; the unknown path is silently dropped. Exit 1 fires only on a failed retrieval of a *matched* file or zero total matches. The spec wording ("exit with 1 if one or more files could not be retrieved") implied otherwise.

<details>
<summary>AI-generated details (reviewed by me)</summary>

Reworded the get exit-code sentence (specs.md get section) to state that exit 1 covers (a) a matched file failing to retrieve (missing/tampered blob) and (b) the zero-match case, and that an explicitly-listed untracked path is resolved against the metadata folder, produces no result, and does not by itself cause a non-zero exit. Spec-only; no code change.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)