### PR TITLE
docs(rpkg): drop stale param signatures from CLAUDE.md exports table

### DIFF
--- a/dvs-rpkg/CLAUDE.md
+++ b/dvs-rpkg/CLAUDE.md
@@ -151,10 +151,12 @@ All defined in `src/rust/lib.rs` with `#[miniextendr]`:
 
 | Function | Purpose | Returns |
 |----------|---------|---------|
-| `dvs_init(storage_path, root_dir?, group?, metadata_folder_name?, no_compression?)` | Initialize a DVS repository | List |
-| `dvs_add(files?, message?, glob?, dry_run?)` | Add files to content-addressable storage | DataFrame |
-| `dvs_status(current?, absent?, unsynced?)` | Report sync status of managed files | DataFrame |
-| `dvs_get(files?, glob?, dry_run?)` | Retrieve files from storage | DataFrame |
+| `dvs_init` | Initialize a DVS repository | List |
+| `dvs_add` | Add files to content-addressable storage | DataFrame |
+| `dvs_status` | Report sync status of managed files | DataFrame |
+| `dvs_get` | Retrieve files from storage | DataFrame |
+
+This table is a high-level index only. The authoritative parameter signatures live in the `#[miniextendr]` definitions in `src/rust/lib.rs` and the R help pages (`?dvs_get` and `man/*.Rd`).
 
 Results are returned as DataFrames using miniextendr's `AsSerializeRow` trait. Errors propagate as `anyhow::Result<T>` converted to R error objects.
 


### PR DESCRIPTION
The "Exported R Functions" table in `dvs-rpkg/CLAUDE.md` listed full parameter signatures that had drifted from the real ones in `src/rust/lib.rs` (recursive args, the status filter collapse, progress callbacks). Rather than re-sync them so they rot again, I cut the signatures and point readers to the authoritative sources.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- The first column of the table now lists only the function name. Purpose and Returns are unchanged.
- Added one sentence below the table noting it is a high-level index and that authoritative signatures live in the `#[miniextendr]` definitions in `src/rust/lib.rs` and the R help pages (`?dvs_get`, `man/*.Rd`).

## Why
The old signatures were stale against `src/rust/lib.rs`:
- `dvs_get` is now `(paths, glob, recursive, dry_run, progress_callback)` (recursive added in #204).
- `dvs_status` is now `(paths, recursive, glob, status)` with the old `current`/`absent`/`unsynced` booleans collapsed into one `status` match-arg vector.
- `dvs_add` gained `progress_callback`.

The root cause was the table duplicating information already authoritative in `src/rust/lib.rs`, the generated `R/dvs-wrappers.R`, and `man/*.Rd`. Removing the volatile column stops the duplication.

## Verification of the rest of the table
Checked the non-signature content against `src/rust/lib.rs`:
- Function set is correct and complete: `dvs_init`, `dvs_add`, `dvs_status`, `dvs_get`. No functions missing or removed.
- Returns column is accurate: `dvs_init` returns a `List`, the other three return `DataFrame`. No changes needed.

_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>