### PR TITLE
fix(core): surface bare directory in add instead of silent drop

### DIFF
--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -79,6 +79,15 @@ pub fn resolve_paths_for_add(
                         out.insert(relative_to_root);
                     }
                 }
+            } else {
+                // Bare directory with no glob: carry it forward so validate_for_add
+                // flags it as IsDirectory and add_files refuses the whole batch,
+                // instead of silently dropping it.
+                let relative_to_root = match full_path.strip_prefix(&repo_root) {
+                    Ok(p) => p.to_path_buf(),
+                    Err(_) => path.clone(),
+                };
+                out.insert(relative_to_root);
             }
         } else {
             bail!("Path is not a file or directory: {}", path.display());
@@ -202,6 +211,33 @@ mod tests {
         assert!(result.contains(&PathBuf::from("data/a.csv")));
         assert!(result.contains(&PathBuf::from("data/subdir/c.csv")));
         assert!(!result.contains(&PathBuf::from("data/b.txt")));
+    }
+
+    #[test]
+    fn add_bare_directory_without_glob_is_carried_forward() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        // A directory with no glob must not be silently dropped. It is carried
+        // forward so validate_for_add flags it as IsDirectory and add_files
+        // refuses the whole batch (see issue #225).
+        let result = resolve_paths_for_add(vec![PathBuf::from("data")], None, &dvs_paths).unwrap();
+
+        assert!(result.contains(&PathBuf::from("data")));
+    }
+
+    #[test]
+    fn add_file_and_bare_directory_keeps_both() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        // Mixing a resolvable file with a bare directory must keep both so the
+        // directory still surfaces and add_files refuses the batch (issue #225).
+        let result = resolve_paths_for_add(
+            vec![PathBuf::from("foo.txt"), PathBuf::from("data")],
+            None,
+            &dvs_paths,
+        )
+        .unwrap();
+
+        assert!(result.contains(&PathBuf::from("foo.txt")));
+        assert!(result.contains(&PathBuf::from("data")));
     }
 
     #[test]


### PR DESCRIPTION
A bare directory passed to `dvs add` (no `--glob`) was silently dropped: no sidecar, no per-file error, exit 0. This makes that explicit argument surface as a per-path "path is a directory" error so the user gets a clear signal and a nonzero exit, while other paths still add (best-effort).

closes #225

<details><summary><h3>AI-written details</h3></summary>

### Root cause

`validate_for_add` (`dvs/src/paths.rs`) and `add_files` (`dvs/src/files/add.rs`) already classify and report `AddPathStatus::IsDirectory` as a per-path `"path is a directory"` error. That branch was dead code in the CLI and R flows because `resolve_paths_for_add` (`dvs/src/globbing.rs`) dropped directories before validation ran: a directory only does anything when combined with a glob (walked and filtered), and with no glob nothing was inserted. A directory mixed with at least one resolvable file therefore vanished from the output with exit 0. A directory passed alone exited 1 via "No files to add".

### Fix

In `resolve_paths_for_add`, when a path is a directory and there is no glob matcher, carry the directory's repo-relative path forward into the resolution set instead of dropping it. It then reaches `validate_for_add`, is classified `IsDirectory`, and `add_files` emits the existing per-path error. No new code path or status was added: the fix reuses the existing `IsDirectory` machinery.

### Design decision

Surfaced as a per-path failure (option a), not a hard fail. This matches the spec ("directories will not work unless combined with a glob", `add` is best-effort and "must not have a recursive option") and aligns with #222, which made `add` best-effort for unresolvable paths. Other paths still process, and the run exits nonzero whenever a directory is among the inputs. The fix lives in dvs core so both the CLI and the R package benefit.

### Before / after

Scratch repo with `good.bin` and a directory `mydir/`:

Before:
```
$ dvs add good.bin mydir --json
[{"path":"good.bin","outcome":"copied",...}]   # mydir absent
exit=0
$ dvs add mydir --json
Error: No files to add
exit=1
```

After:
```
$ dvs add good.bin mydir --json
[{"path":"good.bin","outcome":"copied",...},{"path":"mydir","error":"path is a directory"}]
Error: Some files failed to add
exit=1
$ dvs add mydir --json
[{"path":"mydir","error":"path is a directory"}]
Error: Some files failed to add
exit=1
```

### Tests

Two tests added to the globbing test module, both fail before the change and pass after:
- `add_bare_directory_without_glob_is_carried_forward`: a directory with no glob is carried into the resolution set.
- `add_file_and_bare_directory_keeps_both`: a resolvable file plus a bare directory keeps both, so the directory still surfaces.

`cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test -p dvs` (79 tests) all pass.

</details>