### PR TITLE
fix(core): invalid explicit arg yields non-zero exit, valid work still done (closes #220, #225)

### DIFF
--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -9,12 +9,12 @@ use tabled::Tabled;
 use tabled::settings::{Alignment, Modify, location::ByColumnName, object::Rows};
 
 use dvs::config::Config;
-use dvs::globbing::{resolve_paths_for_add, resolve_paths_for_get, unmatched_tracked_args};
+use dvs::globbing::{resolve_paths_for_add, resolve_paths_for_get};
 use dvs::init::init;
 use dvs::paths::DvsPaths;
 use dvs::{
-    AddDetail, Compression, FileMetadata, FileProgress, FileStatus, GetDetail, Outcome, PathFilter,
-    Status, StatusDetail, add_files, format_size, get_files, get_status, set_num_threads,
+    AddDetail, Compression, FileMetadata, FileProgress, GetDetail, Outcome, PathFilter, Status,
+    StatusDetail, add_files, format_size, get_files, get_status, set_num_threads,
 };
 
 #[derive(Debug, Subcommand)]
@@ -313,10 +313,6 @@ fn try_main() -> Result<()> {
             let dvs_paths = DvsPaths::from_cwd(&config)?;
             let show_all = !current && !absent && !unsynced;
 
-            // An explicitly listed path matching no tracked file is an invalid
-            // argument: report it and exit non-zero, but still show the rest.
-            let unmatched =
-                unmatched_tracked_args(&user_paths, glob.as_deref(), recursive, &dvs_paths)?;
             let filter = if user_paths.is_empty() {
                 None
             } else {
@@ -325,12 +321,6 @@ fn try_main() -> Result<()> {
                 ))
             };
             let mut statuses = get_status(&dvs_paths, filter.as_ref(), glob.as_deref())?;
-            statuses.extend(unmatched.into_iter().map(|path| FileStatus {
-                path,
-                detail: StatusDetail::Error {
-                    error: "not tracked by DVS".to_string(),
-                },
-            }));
             if !show_all {
                 statuses.retain(|x| match &x.detail {
                     StatusDetail::Success { status, .. } => {

--- a/dvs-cli/src/main.rs
+++ b/dvs-cli/src/main.rs
@@ -9,12 +9,12 @@ use tabled::Tabled;
 use tabled::settings::{Alignment, Modify, location::ByColumnName, object::Rows};
 
 use dvs::config::Config;
-use dvs::globbing::{resolve_paths_for_add, resolve_paths_for_get};
+use dvs::globbing::{resolve_paths_for_add, resolve_paths_for_get, unmatched_tracked_args};
 use dvs::init::init;
 use dvs::paths::DvsPaths;
 use dvs::{
-    AddDetail, Compression, FileMetadata, FileProgress, GetDetail, Outcome, PathFilter, Status,
-    StatusDetail, add_files, format_size, get_files, get_status, set_num_threads,
+    AddDetail, Compression, FileMetadata, FileProgress, FileStatus, GetDetail, Outcome, PathFilter,
+    Status, StatusDetail, add_files, format_size, get_files, get_status, set_num_threads,
 };
 
 #[derive(Debug, Subcommand)]
@@ -313,6 +313,10 @@ fn try_main() -> Result<()> {
             let dvs_paths = DvsPaths::from_cwd(&config)?;
             let show_all = !current && !absent && !unsynced;
 
+            // An explicitly listed path matching no tracked file is an invalid
+            // argument: report it and exit non-zero, but still show the rest.
+            let unmatched =
+                unmatched_tracked_args(&user_paths, glob.as_deref(), recursive, &dvs_paths)?;
             let filter = if user_paths.is_empty() {
                 None
             } else {
@@ -321,6 +325,12 @@ fn try_main() -> Result<()> {
                 ))
             };
             let mut statuses = get_status(&dvs_paths, filter.as_ref(), glob.as_deref())?;
+            statuses.extend(unmatched.into_iter().map(|path| FileStatus {
+                path,
+                detail: StatusDetail::Error {
+                    error: "not tracked by DVS".to_string(),
+                },
+            }));
             if !show_all {
                 statuses.retain(|x| match &x.detail {
                     StatusDetail::Success { status, .. } => {

--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -123,34 +123,32 @@ pub fn resolve_paths_for_get(
     let mut out = HashSet::new();
     let glob_matcher = build_glob_matcher(glob_pattern)?;
 
-    // No explicit paths: scope to cwd. A glob matching nothing here stays the
-    // zero-match case (the caller turns an empty set into "No files to get").
-    if paths.is_empty() {
-        let filter = PathFilter::cwd_scoped(recursive, dvs_paths);
-        for tracked_path in dvs_paths.tracked_paths() {
-            if filter.matches(&tracked_path, glob_matcher.as_ref()) {
-                out.insert(tracked_path);
-            }
-        }
-        return Ok(out);
-    }
+    let filter = if paths.is_empty() {
+        PathFilter::cwd_scoped(recursive, dvs_paths)
+    } else {
+        PathFilter::from_user_paths(paths.clone(), recursive, dvs_paths)
+    };
 
     let tracked = dvs_paths.tracked_paths();
-    for path in paths {
-        let filter = PathFilter::from_user_paths(vec![path.clone()], recursive, dvs_paths);
-        let before = out.len();
-        for tracked_path in &tracked {
-            if filter.matches(tracked_path, glob_matcher.as_ref()) {
-                out.insert(tracked_path.clone());
-            }
+    for tracked_path in &tracked {
+        if filter.matches(tracked_path, glob_matcher.as_ref()) {
+            out.insert(tracked_path.clone());
         }
-        if out.len() == before {
-            // This explicit arg matched no tracked file: carry it forward
-            // (repo-root-relative) so validate_for_get reports it.
-            if filter.paths.is_empty() {
+    }
+
+    // Explicit args that matched no tracked file are carried forward (like `add`)
+    // so get_files reports them per-path via validate_for_get. Empty `paths`
+    // (cwd default / glob-only) carries nothing, keeping the zero-match case.
+    for path in paths {
+        let per_arg = PathFilter::from_user_paths(vec![path.clone()], recursive, dvs_paths);
+        if !tracked
+            .iter()
+            .any(|t| per_arg.matches(t, glob_matcher.as_ref()))
+        {
+            if per_arg.paths.is_empty() {
                 out.insert(path);
             } else {
-                out.extend(filter.paths);
+                out.extend(per_arg.paths);
             }
         }
     }

--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -252,6 +252,22 @@ mod tests {
     }
 
     #[test]
+    fn add_missing_path_in_subdir_anchors_to_repo_relative_not_root_namesake() {
+        // Regression (#219): from a subdir, a missing "bar.csv" must be carried
+        // forward as "data/bar.csv" (the intended, nonexistent path), NOT the bare
+        // "bar.csv" - otherwise validate_for_add re-joins it onto repo_root and
+        // would add the unrelated repo-root bar.csv by mistake.
+        let (temp, _) = setup_test_repo();
+        let croot = fs::canonicalize(temp.path()).unwrap();
+        let dvs_paths = DvsPaths::new(croot.join("data"), croot.clone(), ".dvs").unwrap();
+
+        let result =
+            resolve_paths_for_add(vec![PathBuf::from("bar.csv")], None, &dvs_paths).unwrap();
+        assert!(result.contains(&PathBuf::from("data/bar.csv")));
+        assert!(!result.contains(&PathBuf::from("bar.csv")));
+    }
+
+    #[test]
     fn add_valid_plus_missing_keeps_valid_and_carries_missing() {
         let (_temp, dvs_paths) = setup_test_repo();
         let result = resolve_paths_for_add(

--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -110,6 +110,10 @@ fn carry_forward_path(path: &Path, dvs_paths: &DvsPaths) -> PathBuf {
 /// - Explicit files or directories: filtered to tracked files under them
 /// - Glob: matched relative to each path argument, or relative to cwd when no paths are given
 /// - No paths + no glob: returns all tracked files directly under cwd
+///
+/// An explicitly provided path that matches no tracked file is carried forward
+/// (like `add`) so `get_files` reports it per-path (NotTracked / NotFound) and
+/// the command exits non-zero. The tracked matches are still returned.
 pub fn resolve_paths_for_get(
     paths: Vec<PathBuf>,
     glob_pattern: Option<&str>,
@@ -119,59 +123,38 @@ pub fn resolve_paths_for_get(
     let mut out = HashSet::new();
     let glob_matcher = build_glob_matcher(glob_pattern)?;
 
-    // Explicit args that match no tracked file are invalid: carry them forward so
-    // get_files reports them per-path (NotTracked / NotFound) and the exit is
-    // non-zero. Computed before `paths` is moved into the filter.
-    let unmatched = unmatched_tracked_args(&paths, glob_pattern, recursive, dvs_paths)?;
-
-    let filter = if paths.is_empty() {
-        PathFilter::cwd_scoped(recursive, dvs_paths)
-    } else {
-        PathFilter::from_user_paths(paths, recursive, dvs_paths)
-    };
-
-    for tracked_path in dvs_paths.tracked_paths() {
-        if filter.matches(&tracked_path, glob_matcher.as_ref()) {
-            out.insert(tracked_path);
+    // No explicit paths: scope to cwd. A glob matching nothing here stays the
+    // zero-match case (the caller turns an empty set into "No files to get").
+    if paths.is_empty() {
+        let filter = PathFilter::cwd_scoped(recursive, dvs_paths);
+        for tracked_path in dvs_paths.tracked_paths() {
+            if filter.matches(&tracked_path, glob_matcher.as_ref()) {
+                out.insert(tracked_path);
+            }
         }
+        return Ok(out);
     }
 
-    out.extend(unmatched);
-    Ok(out)
-}
-
-/// For each explicitly provided user path, return the ones that match no tracked
-/// file (after glob/recursive filtering), normalized to repo-root-relative form.
-/// Empty `user_paths` (no explicit args, e.g. glob-only or cwd default) returns
-/// empty. Shared by `get` (carried forward) and `status` (reported as errors) so
-/// an invalid argument yields a non-zero exit without aborting the valid work.
-pub fn unmatched_tracked_args(
-    user_paths: &[PathBuf],
-    glob_pattern: Option<&str>,
-    recursive: bool,
-    dvs_paths: &DvsPaths,
-) -> Result<Vec<PathBuf>> {
-    if user_paths.is_empty() {
-        return Ok(Vec::new());
-    }
-    let glob_matcher = build_glob_matcher(glob_pattern)?;
     let tracked = dvs_paths.tracked_paths();
-
-    let mut unmatched = Vec::new();
-    for path in user_paths {
+    for path in paths {
         let filter = PathFilter::from_user_paths(vec![path.clone()], recursive, dvs_paths);
-        let matched = tracked
-            .iter()
-            .any(|t| filter.matches(t, glob_matcher.as_ref()));
-        if !matched {
+        let before = out.len();
+        for tracked_path in &tracked {
+            if filter.matches(tracked_path, glob_matcher.as_ref()) {
+                out.insert(tracked_path.clone());
+            }
+        }
+        if out.len() == before {
+            // This explicit arg matched no tracked file: carry it forward
+            // (repo-root-relative) so validate_for_get reports it.
             if filter.paths.is_empty() {
-                unmatched.push(path.clone());
+                out.insert(path);
             } else {
-                unmatched.extend(filter.paths);
+                out.extend(filter.paths);
             }
         }
     }
-    Ok(unmatched)
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -306,24 +289,12 @@ mod tests {
     }
 
     #[test]
-    fn unmatched_args_flags_only_unmatched() {
+    fn get_glob_only_no_match_returns_empty() {
         let (_temp, dvs_paths) = setup_test_repo();
-        let unmatched = unmatched_tracked_args(
-            &[PathBuf::from("foo.txt"), PathBuf::from("bar.csv")],
-            None,
-            false,
-            &dvs_paths,
-        )
-        .unwrap();
-        // foo.txt is tracked (not flagged); bar.csv is untracked (flagged).
-        assert_eq!(unmatched, vec![PathBuf::from("bar.csv")]);
-    }
-
-    #[test]
-    fn unmatched_args_empty_for_no_explicit_paths() {
-        let (_temp, dvs_paths) = setup_test_repo();
-        let unmatched = unmatched_tracked_args(&[], Some("*.zzz"), false, &dvs_paths).unwrap();
-        assert!(unmatched.is_empty());
+        // A glob with no explicit path that matches nothing stays the zero-match
+        // case (empty set), not a carried-forward error.
+        let result = resolve_paths_for_get(vec![], Some("*.zzz"), &dvs_paths, false).unwrap();
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/dvs/src/globbing.rs
+++ b/dvs/src/globbing.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use crate::paths::{DvsPaths, PathFilter};
-use anyhow::{Result, anyhow, bail};
+use crate::paths::{DvsPaths, PathFilter, normalize_path};
+use anyhow::Result;
 use globset::{GlobBuilder, GlobMatcher};
 use walkdir::WalkDir;
 
@@ -24,6 +24,11 @@ pub(crate) fn build_glob_matcher(pattern: Option<&str>) -> Result<Option<GlobMat
 /// - Explicit files: added directly (glob ignored)
 /// - Explicit directories: walked and filtered by glob
 /// - No paths + glob: walks cwd filtered by glob
+///
+/// An explicitly provided path that resolves to no files (missing on disk, a
+/// bare directory, or a directory whose glob matches nothing) is carried forward
+/// as a repo-root-relative path so `add_files` reports it per-path (NotFound /
+/// IsDirectory) and the command exits non-zero. The valid paths are still added.
 pub fn resolve_paths_for_add(
     paths: Vec<PathBuf>,
     glob_pattern: Option<&str>,
@@ -34,7 +39,8 @@ pub fn resolve_paths_for_add(
     let repo_root = dvs_paths.repo_root().canonicalize()?;
     let metadata_root = dvs_paths.metadata_folder().canonicalize()?;
 
-    // If no paths given, default to cwd
+    // No paths given defaults to cwd; that synthesized path is not carried forward.
+    let explicit = !paths.is_empty();
     let paths = if paths.is_empty() {
         vec![PathBuf::from(".")]
     } else {
@@ -42,50 +48,62 @@ pub fn resolve_paths_for_add(
     };
 
     for path in paths {
-        let full_path = dvs_paths
-            .cwd()
-            .join(&path)
-            .canonicalize()
-            .map_err(|_| anyhow!("Path not found: {}", path.display()))?;
+        let before = out.len();
 
-        // Explicit file: we ignore the glob and add it to the file
-        if full_path.is_file() {
-            let relative_to_root = match full_path.strip_prefix(&repo_root) {
-                Ok(p) => p.to_path_buf(),
-                // Outside repo: insert original user path; validate_for_add will catch it
-                Err(_) => path.clone(),
-            };
-            out.insert(relative_to_root);
-        } else if full_path.is_dir() {
-            if let Some(matcher) = &glob_matcher {
-                for entry in WalkDir::new(&full_path).into_iter().filter_map(|e| e.ok()) {
-                    let entry_path = entry.path().canonicalize()?;
-                    // Skip directories and metadata root folder
-                    if !entry_path.is_file() || entry_path.starts_with(&metadata_root) {
-                        continue;
-                    }
+        if let Ok(full_path) = dvs_paths.cwd().join(&path).canonicalize() {
+            // Explicit file: we ignore the glob and add it to the file
+            if full_path.is_file() {
+                let relative_to_root = match full_path.strip_prefix(&repo_root) {
+                    Ok(p) => p.to_path_buf(),
+                    // Outside repo: insert original user path; validate_for_add will catch it
+                    Err(_) => path.clone(),
+                };
+                out.insert(relative_to_root);
+            } else if full_path.is_dir() {
+                if let Some(matcher) = &glob_matcher {
+                    for entry in WalkDir::new(&full_path).into_iter().filter_map(|e| e.ok()) {
+                        let Ok(entry_path) = entry.path().canonicalize() else {
+                            continue;
+                        };
+                        // Skip directories and metadata root folder
+                        if !entry_path.is_file() || entry_path.starts_with(&metadata_root) {
+                            continue;
+                        }
 
-                    // Get path relative to the walked directory for matching
-                    let relative_to_dir = match entry_path.strip_prefix(&full_path) {
-                        Ok(p) => p,
-                        Err(_) => continue,
-                    };
-                    if matcher.is_match(relative_to_dir) {
-                        // Return path relative to repo root
-                        let relative_to_root = match entry_path.strip_prefix(&repo_root) {
-                            Ok(p) => p.to_path_buf(),
+                        // Get path relative to the walked directory for matching
+                        let relative_to_dir = match entry_path.strip_prefix(&full_path) {
+                            Ok(p) => p,
                             Err(_) => continue,
                         };
-                        out.insert(relative_to_root);
+                        if matcher.is_match(relative_to_dir) {
+                            // Return path relative to repo root
+                            let relative_to_root = match entry_path.strip_prefix(&repo_root) {
+                                Ok(p) => p.to_path_buf(),
+                                Err(_) => continue,
+                            };
+                            out.insert(relative_to_root);
+                        }
                     }
                 }
             }
-        } else {
-            bail!("Path is not a file or directory: {}", path.display());
+        }
+
+        if explicit && out.len() == before {
+            out.insert(carry_forward_path(&path, dvs_paths));
         }
     }
 
     Ok(out)
+}
+
+/// Translate a cwd-relative user path to a normalized repo-root-relative path so
+/// it can be carried into `validate_for_add` / `validate_for_get` for reporting.
+fn carry_forward_path(path: &Path, dvs_paths: &DvsPaths) -> PathBuf {
+    let joined = match dvs_paths.cwd_relative_to_root() {
+        Some(prefix) => prefix.join(path),
+        None => path.to_path_buf(),
+    };
+    normalize_path(joined).unwrap_or_else(|| path.to_path_buf())
 }
 
 /// Resolve paths for `get` command by scanning tracked metadata:
@@ -101,6 +119,11 @@ pub fn resolve_paths_for_get(
     let mut out = HashSet::new();
     let glob_matcher = build_glob_matcher(glob_pattern)?;
 
+    // Explicit args that match no tracked file are invalid: carry them forward so
+    // get_files reports them per-path (NotTracked / NotFound) and the exit is
+    // non-zero. Computed before `paths` is moved into the filter.
+    let unmatched = unmatched_tracked_args(&paths, glob_pattern, recursive, dvs_paths)?;
+
     let filter = if paths.is_empty() {
         PathFilter::cwd_scoped(recursive, dvs_paths)
     } else {
@@ -113,7 +136,42 @@ pub fn resolve_paths_for_get(
         }
     }
 
+    out.extend(unmatched);
     Ok(out)
+}
+
+/// For each explicitly provided user path, return the ones that match no tracked
+/// file (after glob/recursive filtering), normalized to repo-root-relative form.
+/// Empty `user_paths` (no explicit args, e.g. glob-only or cwd default) returns
+/// empty. Shared by `get` (carried forward) and `status` (reported as errors) so
+/// an invalid argument yields a non-zero exit without aborting the valid work.
+pub fn unmatched_tracked_args(
+    user_paths: &[PathBuf],
+    glob_pattern: Option<&str>,
+    recursive: bool,
+    dvs_paths: &DvsPaths,
+) -> Result<Vec<PathBuf>> {
+    if user_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let glob_matcher = build_glob_matcher(glob_pattern)?;
+    let tracked = dvs_paths.tracked_paths();
+
+    let mut unmatched = Vec::new();
+    for path in user_paths {
+        let filter = PathFilter::from_user_paths(vec![path.clone()], recursive, dvs_paths);
+        let matched = tracked
+            .iter()
+            .any(|t| filter.matches(t, glob_matcher.as_ref()));
+        if !matched {
+            if filter.paths.is_empty() {
+                unmatched.push(path.clone());
+            } else {
+                unmatched.extend(filter.paths);
+            }
+        }
+    }
+    Ok(unmatched)
 }
 
 #[cfg(test)]
@@ -184,12 +242,72 @@ mod tests {
     }
 
     #[test]
-    fn add_path_not_found_errors() {
+    fn add_missing_path_is_carried_forward() {
         let (_temp, dvs_paths) = setup_test_repo();
-        let result = resolve_paths_for_add(vec![PathBuf::from("nonexistent")], None, &dvs_paths);
+        // A missing path is no longer a hard error: it is carried forward so
+        // add_files reports it per-path (NotFound) and the command exits non-zero.
+        let result =
+            resolve_paths_for_add(vec![PathBuf::from("nonexistent")], None, &dvs_paths).unwrap();
+        assert!(result.contains(&PathBuf::from("nonexistent")));
+    }
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Path not found"));
+    #[test]
+    fn add_valid_plus_missing_keeps_valid_and_carries_missing() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        let result = resolve_paths_for_add(
+            vec![PathBuf::from("foo.txt"), PathBuf::from("nonexistent")],
+            None,
+            &dvs_paths,
+        )
+        .unwrap();
+        assert!(result.contains(&PathBuf::from("foo.txt")));
+        assert!(result.contains(&PathBuf::from("nonexistent")));
+    }
+
+    #[test]
+    fn add_bare_directory_is_carried_forward() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        // Bare directory (no glob) resolves to no files; carried forward so
+        // add_files reports it as IsDirectory rather than silently dropping it.
+        let result = resolve_paths_for_add(vec![PathBuf::from("data")], None, &dvs_paths).unwrap();
+        assert!(result.contains(&PathBuf::from("data")));
+    }
+
+    #[test]
+    fn get_untracked_explicit_path_is_carried_forward() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        // bar.csv exists on disk but is not tracked; an explicit untracked path
+        // is carried forward so get_files reports it (NotTracked) and exits 1.
+        let result = resolve_paths_for_get(
+            vec![PathBuf::from("foo.txt"), PathBuf::from("bar.csv")],
+            None,
+            &dvs_paths,
+            false,
+        )
+        .unwrap();
+        assert!(result.contains(&PathBuf::from("foo.txt")));
+        assert!(result.contains(&PathBuf::from("bar.csv")));
+    }
+
+    #[test]
+    fn unmatched_args_flags_only_unmatched() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        let unmatched = unmatched_tracked_args(
+            &[PathBuf::from("foo.txt"), PathBuf::from("bar.csv")],
+            None,
+            false,
+            &dvs_paths,
+        )
+        .unwrap();
+        // foo.txt is tracked (not flagged); bar.csv is untracked (flagged).
+        assert_eq!(unmatched, vec![PathBuf::from("bar.csv")]);
+    }
+
+    #[test]
+    fn unmatched_args_empty_for_no_explicit_paths() {
+        let (_temp, dvs_paths) = setup_test_repo();
+        let unmatched = unmatched_tracked_args(&[], Some("*.zzz"), false, &dvs_paths).unwrap();
+        assert!(unmatched.is_empty());
     }
 
     #[test]

--- a/specs.md
+++ b/specs.md
@@ -140,7 +140,8 @@ Returns a list with `status = "initialized"`, invisibly.
 
 ### add
 
-It only takes files as input, directories will not work unless combined with a glob. It can also take an optional
+It only takes files as input, directories will not work unless combined with a glob. A directory passed without a glob
+is reported as an error rather than silently skipped. It can also take an optional
 message that will be recorded in the metadata file. Similarly, `add` must not have a recursive option. The glob mechanism is sufficient, and intentional when used.
 
 This method follows a best-effort approach: even if some files failed to be added, it will still try to add everything
@@ -184,6 +185,9 @@ You can run `dvs add *.csv` and it will be expanded by your shell before calling
 To ensure globs are consistent with the R package, you can use the `--glob` parameter which will be expanded by the library. The glob string must be quoted (for example `--glob '*.csv'`) so the shell does not expand it before `dvs` sees it.
 
 This will exit with `1` if one or more files could not be added to the storage (file does not exist, no permissions, etc).
+An explicitly listed path that resolves to no file is also an error and causes a non-zero exit. This covers a path that
+does not exist on disk and a directory passed without a glob. Such a path is reported per path (for example `path is a
+directory`) while the valid files in the same command are still added.
 
 #### Rust library
 
@@ -244,7 +248,11 @@ Options:
 Passing `-r, --recursive` with an explicit directory walks its subdirectories. It only constrains paths given
 explicitly, so an empty path list still returns every tracked file.
 
-This will exit with `1` if one or more files could not be retrieved.
+This will exit with `1` if one or more files could not be retrieved. A retrieval fails when a matched file's storage
+blob is missing or fails its hash check. An explicitly listed path that matches no tracked file (untracked or missing
+on disk) is also an error and causes a non-zero exit. Such a path is reported per path while the tracked files in the
+same command are still retrieved. A glob given without an explicit path that matches nothing is the zero-match case and
+exits `1` with `No files to get`.
 
 #### Rust library
 
@@ -297,7 +305,10 @@ Options:
 By default (no flags), `dvs status` shows all tracked files regardless of state. The `--current`, `--absent`, and
 `--unsynced` flags are filters: when one or more are provided, only files matching those states are shown.
 
-This will exit with `1` if one or more files could not be inspected.
+This will exit with `1` if one or more files could not be inspected. An explicitly listed path that matches no tracked
+file is also an error and causes a non-zero exit. Such a path is reported per path while the tracked files in the same
+command are still shown. A glob given without an explicit path that matches nothing is not an error for `status`. It
+prints an empty result and exits `0`, because a read-only pattern scan with zero matches is a valid outcome.
 
 #### Rust library
 

--- a/specs.md
+++ b/specs.md
@@ -305,10 +305,7 @@ Options:
 By default (no flags), `dvs status` shows all tracked files regardless of state. The `--current`, `--absent`, and
 `--unsynced` flags are filters: when one or more are provided, only files matching those states are shown.
 
-This will exit with `1` if one or more files could not be inspected. An explicitly listed path that matches no tracked
-file is also an error and causes a non-zero exit. Such a path is reported per path while the tracked files in the same
-command are still shown. A glob given without an explicit path that matches nothing is not an error for `status`. It
-prints an empty result and exits `0`, because a read-only pattern scan with zero matches is a valid outcome.
+This will exit with `1` if one or more files could not be inspected.
 
 #### Rust library
 


### PR DESCRIPTION
An invalid explicit argument should produce an error code, but the part of the operation that can be done correctly should still be done. Previously a path that resolved to nothing was silently dropped with exit 0. This fixes that for `add` and `get`.

<details>
<summary>AI-generated details (reviewed by me)</summary>

### Behavior

An explicitly listed path that resolves to no file is now reported per path and causes a non-zero exit. The valid paths in the same command are still processed.

| command | before | after |
| --- | --- | --- |
| `dvs add good.bin mydir` | adds good.bin, drops `mydir`, exit 0 | adds good.bin, reports `mydir` as `path is a directory`, **exit 1** |
| `dvs get good.bin untracked.bin` | gets good.bin, drops untracked, exit 0 | gets good.bin, reports `not tracked by DVS`, **exit 1** |
| `dvs get good.bin nope.bin` | gets good.bin, drops nope, exit 0 | gets good.bin, reports `file not found`, **exit 1** |

A glob given without an explicit path keeps its prior behavior: `add`/`get` exit 1 with `No files to X`.

### Implementation

Entirely in `dvs/src/globbing.rs`, no CLI changes, no new public API. An explicit path that resolves to nothing is carried forward so the existing per-path validation reports it:

- `add`: `resolve_paths_for_add` carries an unresolved explicit arg forward (missing path, bare directory, special file) so `add_files` reports it via `validate_for_add` (`NotFound` / `IsDirectory`). Carried paths are anchored repo-root-relative so a same-named file at the repo root is not added by mistake when run from a subdir.
- `get`: `resolve_paths_for_get` carries an explicit arg matching no tracked file forward so `get_files` reports it via `validate_for_get` (`NotTracked` / `NotFound`).

Signatures are unchanged, so the R package (`dvs_add` / `dvs_get`) inherits the fix with no code change.

### Scope: status

`status` is intentionally not changed here. It is read-only and the same fix belongs in the core rather than the CLI so the R package stays consistent. Tracked in #237 with a draft branch.

### Related PRs

- **#222 / #219** (best-effort add resolution): subsumed. This PR covers the same `add` case plus the bare-directory case (#225) and `get` (#220), and ports #222's subdir-namesake regression test. Recommend merging this and closing #222.
- **#230** (docs: get exit-code): superseded, it documented the silent-drop-exit-0 as intended. Recommend closing.
- **#231** (docs: status zero-match): unaffected, status is unchanged here.

### Tests

Unit tests in `globbing.rs` cover add (missing, valid+missing, bare dir, subdir-anchor regression), get (untracked carried forward), and the glob-only zero-match path. Full suite green. Verified end-to-end with the built CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)