### PR TITLE
test(ui): flip add/get assertions to fail-fast all-or-nothing (#240)

### DIFF
--- a/ui/audit_violations.sh
+++ b/ui/audit_violations.sh
@@ -60,16 +60,16 @@ ok=1
 [ "$rc" -eq 0 ] && [ -f data/d1.bin ] && [ -f data/d2.bin ] && ok=0
 verdict "$ok" "#217 'get data --glob \"*.bin\"' retrieves the files (like 'add')"
 
-# ── #219 — add best-effort vs an unresolvable (missing) path ──
-note "#219 add valid + missing path (best-effort, specs.md L133/L173)"
+# ── #219/#240 — add valid + unresolvable (missing) path refuses the batch ──
+note "#240 add valid + missing path refuses the whole batch (all-or-nothing, specs.md L146/L186)"
 fresh_project
 head -c 1024 /dev/urandom > ok.bin
-rc=0; out="$(dvs add ok.bin missing.bin --json 2>/dev/null)" || rc=$?
+rc=0; out="$(dvs add ok.bin missing.bin --json 2>&1)" || rc=$?
 ok=1
-[ -f .dvs/ok.bin.dvs ] \
+[ ! -e .dvs/ok.bin.dvs ] \
   && printf '%s' "$out" | grep -q 'missing.bin' \
   && [ "$rc" -eq 1 ] && ok=0
-verdict "$ok" "#219 best-effort: ok.bin added, missing.bin reported per-file, exit 1"
+verdict "$ok" "#240 all-or-nothing: ok.bin NOT added, missing.bin named, exit 1"
 
 echo
 echo "######## Section B: spec divergences (informational) ########"
@@ -84,17 +84,17 @@ else
   echo "ALIGNED:  #218 'status' accepts --glob"
 fi
 
-# ── #220 — get exit code on an explicitly-requested unknown path ──
-note "#220 get valid + unknown path"
+# ── #220/#240 — get refuses the batch on an explicitly-requested unknown path ──
+note "#240 get valid + unknown path refuses the batch"
 fresh_project
 head -c 1024 /dev/urandom > f.bin
 dvs add f.bin >/dev/null 2>&1
 rm -f f.bin
 rc=0; dvs get f.bin nope.bin --json >/dev/null 2>&1 || rc=$?
-if [ "$rc" -eq 1 ]; then
-  echo "ALIGNED:  #220 get exits 1 when an explicitly-requested path is unknown"
+if [ "$rc" -eq 1 ] && [ ! -e f.bin ]; then
+  echo "ALIGNED:  #240 get exits 1 and retrieves nothing when an explicit path is unknown"
 else
-  echo "DIVERGES: #220 get exit=$rc; unknown requested path is silently dropped (specs.md L230 wording)"
+  echo "DIVERGES: #240 get exit=$rc, f.bin present=$([ -e f.bin ] && echo yes || echo no); unknown path no longer refuses the batch"
 fi
 
 cd "$SCRIPT_DIR"

--- a/ui/validate_add.sh
+++ b/ui/validate_add.sh
@@ -129,17 +129,17 @@ say "$OUT"
 check "1" "$rc" "exit code 1 when a path is missing"
 
 # =====================================================================
-# best-effort also covers UNRESOLVABLE input paths (#219): a missing path is
-# reported per-file (NotFound) and does NOT abort the add of valid siblings.
+# An unresolvable input path now refuses the WHOLE batch (#240): no valid
+# sibling is added, the missing path is named, and the command exits 1.
 say
-say "=== CLAIM: best-effort, valid+missing path -> valid added, missing reported, exit 1 (L133,L173,#219) ==="
+say "=== CLAIM: all-or-nothing, any invalid input path refuses the whole batch, exit 1 (L146,L186,#240) ==="
 mkrandfile sibling.bin 256
 rc=0; OUT="$(dvs add --json sibling.bin gone.bin 2>&1)" || rc=$?
 say "$OUT"
-check "YES" "$([ -e .dvs/sibling.bin.dvs ] && echo YES || echo NO)" "best-effort: valid sibling.bin added despite a missing sibling path"
+check "NO" "$([ -e .dvs/sibling.bin.dvs ] && echo YES || echo NO)" "all-or-nothing: valid sibling.bin NOT added when a sibling path is missing"
 REPORTED_MISS="$(printf '%s' "$OUT" | grep -qiE 'gone.bin' && echo yes || echo no)"
-check "yes" "$REPORTED_MISS" "best-effort: missing gone.bin reported per-file in output"
-check "1" "$rc" "exit code 1 when a path is missing but valid siblings still added"
+check "yes" "$REPORTED_MISS" "the missing gone.bin is named in the refusal message"
+check "1" "$rc" "exit code 1 when any input path is missing"
 
 # =====================================================================
 say

--- a/ui/validate_get.sh
+++ b/ui/validate_get.sh
@@ -148,13 +148,13 @@ say "=== Claim: exit code 1 if one or more files could not be retrieved (L230) =
 # (a) requested path has no metadata at all -> nothing matches -> exit 1.
 rc=0; dvs get does/not/exist.bin >/dev/null 2>&1 || rc=$?
 check "1" "$rc" "exit 1 when requested path has no metadata (L230)"
-# FINDING: a path with no metadata mixed with a valid one does NOT cause exit 1.
-# Paths resolve against the metadata folder (L208); an unknown path simply is
-# not in the resolution set, so it is silently dropped and the valid file is
-# retrieved with exit 0.  Documented, not asserted as failure.
+# A path with no metadata mixed with a valid one now refuses the WHOLE batch
+# (#240): each explicit path must resolve to a tracked file, otherwise the
+# request is refused, nothing is retrieved, and the command exits 1.
 rm -f data/raw/file_1.bin
 rc=0; dvs get data/raw/file_1.bin no/such.bin >/dev/null 2>&1 || rc=$?
-check "0" "$rc" "missing-metadata path silently dropped; valid file still retrieved, exit 0 (L208/L230 finding)"
+check "1" "$rc" "untracked path mixed with a valid one refuses the whole batch, exit 1 (#240)"
+check "no" "$([ -f data/raw/file_1.bin ] && echo yes || echo no)" "all-or-nothing: valid file NOT retrieved when a sibling path is untracked (#240)"
 # The genuine partial-failure -> exit 1 case (one matched file that FAILS to
 # retrieve) is exercised in the hash-mismatch section below.
 


### PR DESCRIPTION
Updates the CLI validation suite to match PR #240. The #219 best-effort and #220 silent-drop assertions are flipped to assert the new all-or-nothing behavior. Verified against a CLI built from #240.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `validate_add.sh`: the #219 case now asserts a valid sibling is NOT added when another input path is missing, the missing path is named, and exit is 1.
- `validate_get.sh`: the #220 case now asserts a valid path mixed with an untracked one refuses the whole batch (exit 1, nothing retrieved) instead of exit 0.
- `audit_violations.sh`: the #219 Section A guard flips to assert all-or-nothing; the #220 Section B note flips to confirm the batch is refused. Section A now reports one expected failure (#216 dedup, still open and unrelated to #240).

## Test plan
- [ ] `bash ui/audit_violations.sh` -> Section A: 1 fail (#216 only).
- [ ] `bash ui/validate_add.sh` -> 38 pass, 0 fail.
- [ ] `bash ui/validate_get.sh` -> 22 pass, 1 fail (pre-existing get `--help` staleness, unrelated).

## Notes
- Pairs with the spec PR on `main` (#241, `spec/240-fail-fast-canonical`).
- The remaining `validate_get.sh` failure is the get `--help` block drifting from this branch's stale `specs.md`, not a behavior issue.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>