### PR TITLE
chore(rpkg): bump dvs pin to adopt #240 fail-fast add/get

### DIFF
--- a/dvs-rpkg/src/rust/Cargo.lock
+++ b/dvs-rpkg/src/rust/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 [[package]]
 name = "dvs"
 version = "0.3.0"
-source = "git+https://github.com/A2-ai/dvs2?branch=main#ea5e6901de6838406ff3595704598d61d3a44aa2"
+source = "git+https://github.com/A2-ai/dvs2?branch=main#3fe17daaa8d6b796da40b4c64650f3a61be63f8b"
 dependencies = [
  "anyhow",
  "blake3",


### PR DESCRIPTION
Bumps the dvs git pin so dvs-rpkg picks up #240's fail-fast add/get behavior, which is already on main for the CLI but was still pinned to a pre-#240 dvs in the R package's Cargo.lock. No R API surface change. PR #244 (the per-file-failure warning + tests) stacks on this.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Bumps the dvs git dependency in `dvs-rpkg/src/rust/Cargo.lock` from `ea5e6901de6838406ff3595704598d61d3a44aa2` (pre-#240) to `3fe17daaa8d6b796da40b4c64650f3a61be63f8b` (current main tip, which contains #240 via squash commit `ff4fb23`).
- Verified dvs-only bump: the Cargo.lock diff is a single line (the dvs `source` SHA). The miniextendr pin (`68b6b207...`) is untouched, achieved via `cargo update --package dvs` rather than a bare update.
- R package behavior now matches the merged CLI: `dvs_add` and `dvs_get` fail fast and all-or-nothing on invalid inputs instead of silently dropping bad paths.

## Test plan
- [x] Full rpkg build under R 4.5 + roxygen 7.3.2: `rpkg-update --package dvs` then `rpkg-configure`, `rpkg-install`, `rpkg-document`. The install log shows `Compiling dvs v0.3.0 (https://github.com/A2-ai/dvs2?branch=main#3fe17daa)` (a git source at the new SHA, not a local path) and ends `* DONE (dvs)`.
- [x] Behavior probe against the freshly installed package: `dvs_get(c("good.csv", "untracked.csv"))` now raises "The following paths are not tracked by DVS: untracked.csv", and `dvs_add(c("good2.csv", "missing.csv"))` now raises "Path not found: missing.csv". Pre-#240 the get returned a frame with the bad path silently dropped.
- [x] Existing R testthat suite passes apart from the known-unrelated `test-get.R:56:3` nested-fixture failure (a `write_theoph_shuffled` helper writing to `data/raw/deep.csv` that does not exist in the test working directory), which is unrelated to this pin bump.

## Notes
- No R API surface change: #240 did not alter the `dvs_add`/`dvs_get` signatures, so `rpkg-document` produced no diff. The only committed change is the one-line Cargo.lock pin. No `man/*.Rd`, `NAMESPACE`, `R/dvs-wrappers.R`, or `DESCRIPTION` churn, and no RoxygenNote/version-string churn that would signal a wrong R version.
- Source mode (no `inst/vendor.tar.xz`); no `[patch]` block added. This bumps the real committed `branch=main` git pin.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
