### PR TITLE
chore(deps): hoist uuid v4 feature to the workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ md5 = "0.8.0"
 jiff = { version = "0.2.18", features = ["serde"] }
 anyhow = "1.0.100"
 whoami = "2"
-uuid = "1.20.0"
+uuid = { version = "1.20.0", features = ["v4"] }
 zstd = "0.13.3"
 rusqlite = { version = "0.38", features = ["bundled"] }
 globset = "0.4"

--- a/dvs/Cargo.toml
+++ b/dvs/Cargo.toml
@@ -22,7 +22,7 @@ anyhow.workspace = true
 whoami.workspace = true
 zstd.workspace = true
 rusqlite.workspace = true
-uuid = { version = "1.20.0", features = ["v4"] }
+uuid.workspace = true
 globset.workspace = true
 rayon.workspace = true
 


### PR DESCRIPTION
Declare the `v4` feature once on the workspace `uuid` entry in the root `Cargo.toml` and let `dvs` inherit it via `uuid.workspace = true`, instead of repeating the full `{ version, features }` spec in `dvs/Cargo.toml`.

<details>
<summary>🤖 Details (AI-written)</summary>

**No functional change.** `dvs` already resolved `uuid` with the `v4` feature, so `Cargo.lock` is unaffected (verified: `cargo check -p dvs` passes, `git status` shows `Cargo.lock` unchanged).

This was split out of unrelated working-tree changes so it can land as a self-contained dependency-hygiene PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>