### PR TITLE
test(rpkg): fix nested-path fixture and recursive-get expectation in test-get.R

### DIFF
--- a/dvs-rpkg/tests/testthat/helper-theoph.R
+++ b/dvs-rpkg/tests/testthat/helper-theoph.R
@@ -1,10 +1,18 @@
+# Create the parent directory so callers can pass nested paths (e.g.
+# "data/raw/deep.csv"); write.csv() does not create it.
+ensure_parent_dir <- function(path) {
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+}
+
 write_theoph <- function(path) {
+  ensure_parent_dir(path)
   data <- datasets::Theoph
   utils::write.csv(data, file = path, row.names = FALSE)
   invisible(path)
 }
 
 write_theoph_shuffled <- function(path, seed) {
+  ensure_parent_dir(path)
   data <- datasets::Theoph
   set.seed(seed)
   data <- data[sample(nrow(data)), , drop = FALSE]

--- a/dvs-rpkg/tests/testthat/test-get.R
+++ b/dvs-rpkg/tests/testthat/test-get.R
@@ -50,14 +50,14 @@ test_that("dvs_get on never-added path errors", {
   expect_error(dvs_get(paths = "never-added.csv"))
 })
 
-test_that("dvs_get() with no args restores every tracked file at every depth", {
+test_that("dvs_get(recursive = TRUE) with no paths restores every tracked file at every depth", {
   new_dvs_test_repo()
   write_theoph("top.csv")
   write_theoph_shuffled("data/raw/deep.csv", seed = 1)
   dvs_add(paths = file.path(getwd(), c("top.csv", "data/raw/deep.csv")))
   file.remove(c("top.csv", "data/raw/deep.csv"))
 
-  result <- dvs_get()
+  result <- dvs_get(recursive = TRUE)
   expect_s3_class(result, "tbl_df")
   expect_setequal(result$path, c("top.csv", "data/raw/deep.csv"))
   expect_true(all(file.exists(c("top.csv", "data/raw/deep.csv"))))


### PR DESCRIPTION
The "restores every tracked file at every depth" test in `test-get.R` was failing for two reasons. This fixes both so the rpkg testthat suite passes.

<details>
<summary>🤖 Details (AI-written)</summary>

**1. Fixture bug (the original report).** The test wrote a fixture to `data/raw/deep.csv`, but the `write_theoph` / `write_theoph_shuffled` helpers call `utils::write.csv()` directly without creating the parent directory, so the test errored at setup with *"cannot open file 'data/raw/deep.csv': No such file or directory"*. The helpers now create the parent dir via `dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)`.

**2. Wrong expectation, exposed once the fixture ran.** The test called `dvs_get()` with no paths and expected both `top.csv` and the nested `data/raw/deep.csv` to be restored. But no-paths get restores only the files **directly under** the working directory — restoring every tracked file at any depth requires `recursive = TRUE`. This is the documented behavior (`dvs_get` Rust doc) and is covered by the core globbing unit tests `get_no_paths_non_recursive_returns_direct_children` and `get_no_paths_recursive_returns_all_under_cwd`. The test now passes `recursive = TRUE` and is renamed to match.

Verified: full `devtools::test("dvs-rpkg")` under R 4.5 passes with no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>