### PR TITLE
docs(spec): correct get no-paths and recursive behavior

### DIFF
--- a/specs.md
+++ b/specs.md
@@ -235,13 +235,12 @@ Options:
       --json               Output results as JSON
       --threads <THREADS>  Number of threads for parallel operations (0 = auto-detect)
   -g, --glob <GLOB>        
-  -r, --recursive          Recursively include files in subdirectories for directory inputs. Without this flag, directories return only their direct children. Has no effect when no explicit paths are given
+  -r, --recursive          Recursively include files in subdirectories for directory inputs. Without this flag, directories return only their direct children.
       --dry-run            Show what would be retrieved without making any actual changes
   -h, --help               Print help
 ```
 
-Passing `-r, --recursive` with an explicit directory walks its subdirectories. It only constrains paths given
-explicitly, so an empty path list still returns every tracked file.
+Passing `-r, --recursive` with an explicit directory walks its subdirectories. Without it, a directory returns only its direct children. `recursive` only affects directories named on the command line. The CLI always requires at least one path or `--glob`, so there is no bare `dvs get`. To retrieve every tracked file regardless of depth, pass `--glob '**/*'`.
 
 A request that names a path with no tracked file (never added, or misspelled) is refused as a whole, retrieves nothing, and exits with `1`. A request that resolves but has one or more files fail on retrieval (for example a hash mismatch) retrieves the rest and also exits with `1`.
 
@@ -256,9 +255,9 @@ Otherwise it returns a list of results sorted alphabetically by path, letting us
 dvs_get(paths = character(0), glob = NULL, recursive = NULL, dry_run = NULL)
 ```
 
-- `paths`: character vector of file paths to retrieve (can be empty if `glob` is provided)
+- `paths`: character vector of file paths to retrieve. If empty with no `glob`, `dvs_get()` scopes to the working directory and restores the files directly under it
 - `glob`: pattern to match files in the metadata folder (same resolution rules as CLI `--glob`)
-- `recursive`: if `TRUE`, walk explicit directory paths recursively (same as the CLI `-r, --recursive`)
+- `recursive`: if `TRUE`, walk explicit directory paths recursively (same as the CLI `-r, --recursive`). With empty `paths`, `recursive = TRUE` restores every tracked file under the working directory at any depth
 - `dry_run`: if `TRUE`, returns what would be retrieved without making changes
 
 Returns a data frame with one row per file.


### PR DESCRIPTION
The `get` section of `specs.md` described no-paths and `--recursive` behavior that doesn't match the implementation, and one claim contradicted the command help printed a few lines above it.

<details>
<summary>🤖 Details (AI-written)</summary>

Two wrong statements:
- "an empty path list still returns every tracked file" (line 244) — contradicts the command help at line 227, which already states "At least one path or --glob must be provided; to restore every tracked file, pass `--glob '**/*'`".
- "Has no effect when no explicit paths are given" appended to the reproduced `--recursive` help — this sentence is **not** in the actual binary output (`dvs-cli/src/main.rs:92-93`); it was added only in the spec.

Corrected to the real behavior, verified against the `dvs_get` Rust doc (`dvs-rpkg/src/rust/lib.rs:423-426`) and the core globbing unit tests `get_no_paths_non_recursive_returns_direct_children` and `get_no_paths_recursive_returns_all_under_cwd`:

- **CLI** requires at least one path or `--glob` (`required_unless_present = "glob"`). There is no bare `dvs get`. Restore everything with `--glob '**/*'`.
- **R** `dvs_get()` allows empty `paths` with no `glob` and scopes to the working directory: direct children only, or every tracked file at any depth with `recursive = TRUE`. (The text looks copy-pasted from `status`, where recursive genuinely has no effect.)

Surfaced while fixing the rpkg `test-get.R` recursive expectation (#247). Spec-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>