### PR TITLE
chore(deps): align rpkg crate deps with the dvs library versions

### DIFF
--- a/dvs-rpkg/src/rust/Cargo.toml
+++ b/dvs-rpkg/src/rust/Cargo.toml
@@ -36,8 +36,8 @@ connections = ["miniextendr-api/connections"]
 miniextendr-api = { git = "https://github.com/A2-ai/miniextendr", features = ["serde", "time", "log"] }
 dvs = { git = "https://github.com/A2-ai/dvs2", branch = "main", package = "dvs" }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-anyhow = "1"
+serde_json = "1.0.149"
+anyhow = "1.0.100"
 
 [build-dependencies]
 miniextendr-lint = { git = "https://github.com/A2-ai/miniextendr" }


### PR DESCRIPTION
Pin `serde_json` and `anyhow` in the dvs-rpkg crate to the exact versions the `dvs` library crate uses, so the FFI crate and the core crate resolve to the same dependency versions.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- `dvs-rpkg/src/rust/Cargo.toml`: `serde_json = "1"` -> `serde_json = "1.0.149"`, `anyhow = "1"` -> `anyhow = "1.0.100"`, matching the workspace `Cargo.toml` and the vendored `dvs-rpkg/vendor/dvs/Cargo.toml`.
- `serde` already matched at `"1"` (with `derive`), so it was left unchanged.
- Only the three deps the rpkg crate declares directly (shared across the FFI boundary with `dvs`) are in scope; the rest come transitively from the `dvs` git dependency.

## Test plan
- [ ] `just rpkg-configure && just rpkg-install` resolves and builds with the pinned versions.
- [ ] `cargo metadata --manifest-path dvs-rpkg/src/rust/Cargo.toml` shows a single resolved version each for `serde_json` and `anyhow`.

## Notes
- The vendored `vendor/dvs/Cargo.toml` is auto-generated and is not touched here; it is only the reference for the canonical versions.

---
_Drafted by Claude (claude-opus-4-8). Reviewed by the author._

</details>
