### PR TITLE
docs(spec): status drops non-matching paths silently

### DIFF
--- a/specs.md
+++ b/specs.md
@@ -298,6 +298,10 @@ By default (no flags), `dvs status` shows all tracked files regardless of state.
 
 This will exit with `1` if one or more files could not be inspected.
 
+Each named path filters independently. A path that matches no tracked file is dropped silently rather than
+failing the command, so a partly misspelled invocation such as `dvs status good.bin bogus.bin` still exits
+`0` and shows only the paths that matched.
+
 #### Rust library
 
 The library scans all metadata files in the project and returns a result for each one. Like `add` and `get`,


### PR DESCRIPTION
Documents that `dvs status` filters each named path independently, so a partly wrong invocation exits `0` instead of failing. Spec-only, no code change. Verified empirically on `origin/main`.

<details>
<summary>AI-generated details (reviewed by me)</summary>

`status` iterates the tracked set and applies each path/glob as a predicate (`PathFilter::matches`), so a path that matches nothing is dropped rather than validated. This differs from `add`/`get`, which refuse the whole batch on one bad path (#240 fail-fast).

```
$ dvs status good.bin bogus.bin   # exit 0, shows only good.bin
$ dvs get    good.bin bogus.bin   # exit 1, "not tracked by DVS", retrieves nothing
$ dvs add    good.bin bogus.bin   # exit 1, "Path not found", adds nothing
```

Complements #231 (status zero-match exit 0 + trailing-slash). Merges cleanly with #231 in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>